### PR TITLE
Change TreeReader::Error bound from std to anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
 [workspace.dependencies]
 # External dependencies
 anyhow = "1.0.68"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" } 
 borsh = { version = "0.10.0", features = ["rc"]}
 byteorder = "1.4.3"
 bytes = "1.2.1"

--- a/jmt/Cargo.toml
+++ b/jmt/Cargo.toml
@@ -15,15 +15,17 @@ thiserror = { workspace = true }
 prometheus = { workspace = true, default-features = false, optional = true }
 once_cell = { workspace = true, optional = true }
 
-# Dependencies for "fuzzing" feature. Also relies on "metrics"
+# Dependencies for "fuzzing" feature. Also relies on "metrics" and "borsh"
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true, features = ["min_const_gen"], optional = true}
-bcs = { workspace = true, optional = true } 
 tiny-keccak = { workspace = true, features = ["keccak", "sha3"], optional = true }
 
 # Dependencies for "rayon" feature
 rayon = { workspace = true, optional = true }
+
+# Dependencies for "borsh" feature
+borsh = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -33,10 +35,11 @@ tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 prometheus = { version = "0.13.3", default-features = false }
 once_cell = "1.10.0" 
 rayon =  "1.5.2"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" } # Used to make all serializable types hashable
+borsh = { workspace = true }
 
 [features]
 default = []
-fuzzing = ["dep:proptest", "dep:proptest-derive", "dep:rand", "dep:bcs", "dep:tiny-keccak"]
+fuzzing = ["borsh", "dep:proptest", "dep:proptest-derive", "dep:rand", "dep:tiny-keccak"]
 metrics = ["dep:prometheus", "dep:once_cell"]
 rayon = ["dep:rayon", "dep:once_cell"]
+borsh = ["dep:borsh"]

--- a/jmt/Cargo.toml
+++ b/jmt/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
 byteorder = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -1103,6 +1103,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod test {
+    use borsh::BorshSerialize;
     use proptest::prelude::Arbitrary;
     use serde::ser;
 
@@ -1129,9 +1130,9 @@ mod test {
         fn test_only_hash(&self) -> TestHashValue;
     }
 
-    impl<T: ser::Serialize + ?Sized> TestOnlyHash for T {
+    impl<T: BorshSerialize + ?Sized> TestOnlyHash for T {
         fn test_only_hash(&self) -> TestHashValue {
-            let bytes = bcs::to_bytes(self).expect("serialize failed during hash.");
+            let bytes = borsh::to_vec(self).expect("serialize failed during hash.");
             HashOutput::sha3_256_of(&bytes)
         }
     }

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -1105,7 +1105,6 @@ pub mod test_utils {
 mod test {
     use borsh::BorshSerialize;
     use proptest::prelude::Arbitrary;
-    use serde::ser;
 
     use crate::{hash::HashOutput, types::nibble::Nibble, Key};
 

--- a/jmt/src/mock_tree_store.rs
+++ b/jmt/src/mock_tree_store.rs
@@ -59,15 +59,15 @@ where
     K: crate::test_utils::TestKey,
     H: TreeHash<N>,
 {
-    type Error = BoxError;
-    fn get_node_option(&self, node_key: &NodeKey<N>) -> Result<Option<Node<K, H, N>>, BoxError> {
+    type Error = anyhow::Error;
+    fn get_node_option(&self, node_key: &NodeKey<N>) -> Result<Option<Node<K, H, N>>, Self::Error> {
         Ok(self.data.read().unwrap().0.get(node_key).cloned())
     }
 
     fn get_rightmost_leaf(
         &self,
         version: Version,
-    ) -> Result<Option<(NodeKey<N>, LeafNode<K, H, N>)>, BoxError> {
+    ) -> Result<Option<(NodeKey<N>, LeafNode<K, H, N>)>, Self::Error> {
         let locked = self.data.read().unwrap();
         let mut node_key_and_node: Option<(NodeKey<N>, LeafNode<K, H, N>)> = None;
 
@@ -88,7 +88,7 @@ where
 
     fn get_node(&self, node_key: &NodeKey<N>) -> std::result::Result<Node<K, H, N>, Self::Error> {
         self.get_node_option(node_key)?
-            .ok_or_else(|| BoxError(Box::new(TestTreeError::MissingNode)))
+            .ok_or_else(|| TestTreeError::MissingNode.into())
     }
 }
 

--- a/jmt/src/node_type/mod.rs
+++ b/jmt/src/node_type/mod.rs
@@ -636,6 +636,7 @@ impl<H: TreeHash<N>, const N: usize> InternalNode<H, N> {
                 let only_child_node_key =
                     node_key.gen_child_node_key(only_child.version, only_child_index);
                 match tree_reader.get_node(&only_child_node_key).map_err(|e| {
+                    let e: anyhow::Error = e.into();
                     CodecError::NodeFetchError {
                         key: format!("{:?}", &only_child_node_key),
                         err: e.to_string(),

--- a/jmt/src/node_type/mod.rs
+++ b/jmt/src/node_type/mod.rs
@@ -46,6 +46,10 @@ pub struct NodeKey<const N: usize> {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 /// A type-erased [`NodeKey`] - with no knowledge of the JMTs hash function or digest size.
 /// Allows the creation of database abstractions without excessive generics.
 pub struct PhysicalNodeKey {
@@ -173,6 +177,10 @@ impl<const N: usize> NodeKey<N> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub enum NodeType {
     Leaf,
     Null,
@@ -212,12 +220,16 @@ pub struct Child<const N: usize> {
     pub node_type: NodeType,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
 /// A type-erased [`Child`] - with no knowledge of the JMTs hash function or digest size.
 /// Allows the creation of database abstractions without excessive generics.
 ///
 /// Introduces a slight inefficiency, since "hash" values have to be copied to transform from
 /// Vec to array types on conversion to [`Child`], but the performance impace should be negligble.
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub struct PartialChild {
     /// The hash value of this child node.
     hash: Vec<u8>,
@@ -295,9 +307,13 @@ impl<H, const N: usize> Clone for InternalNode<H, N> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
 /// A type-erased [`InternalNode`] - with no knowledge of the JMTs hash function or digest size.
 /// Allows the creation of database abstractions without excessive generics.
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub struct PartialInternalNode {
     /// Up to 16 children.
     children: PartialChildren,
@@ -1050,9 +1066,13 @@ where
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
 /// A type-erased [`Node`] - with no knowledge of the JMTs hash function or digest size.
 /// Allows the creation of database abstractions without excessive generics.
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub enum PhysicalNode<K> {
     /// A wrapper of [`InternalNode`].
     Internal(PartialInternalNode),

--- a/jmt/src/node_type/mod.rs
+++ b/jmt/src/node_type/mod.rs
@@ -314,17 +314,17 @@ impl<H, const N: usize> Clone for InternalNode<H, N> {
     any(test, feature = "borsh"),
     derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
 )]
-pub struct PartialInternalNode {
+pub struct PhysicalInternalNode {
     /// Up to 16 children.
     children: PartialChildren,
     /// Total number of leaves under this internal node
     leaf_count: usize,
 }
 
-impl<H, const N: usize> TryFrom<PartialInternalNode> for InternalNode<H, N> {
+impl<H, const N: usize> TryFrom<PhysicalInternalNode> for InternalNode<H, N> {
     type Error = CodecError;
 
-    fn try_from(value: PartialInternalNode) -> Result<Self, Self::Error> {
+    fn try_from(value: PhysicalInternalNode) -> Result<Self, Self::Error> {
         let children: Result<HashMap<Nibble, Child<N>>, CodecError> = value
             .children
             .into_iter()
@@ -779,19 +779,23 @@ pub struct LeafNode<K, H, const N: usize> {
     phantom_hasher: std::marker::PhantomData<H>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 /// A type-erased [`LeafNode`] - with no knowledge of the JMTs hash function or digest size.
 /// Allows the creation of database abstractions without excessive generics.
-pub struct PartialLeafNode<K> {
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
+pub struct PhysicalLeafNode<K> {
     account_key: Vec<u8>,
     value_hash: Vec<u8>,
     value_index: (K, Version),
 }
 
-impl<K, H, const N: usize> TryFrom<PartialLeafNode<K>> for LeafNode<K, H, N> {
+impl<K, H, const N: usize> TryFrom<PhysicalLeafNode<K>> for LeafNode<K, H, N> {
     type Error = errors::CodecError;
 
-    fn try_from(value: PartialLeafNode<K>) -> Result<Self, Self::Error> {
+    fn try_from(value: PhysicalLeafNode<K>) -> Result<Self, Self::Error> {
         let account_key = KeyHash(HashOutput::from_slice(value.account_key)?);
         let value_hash = ValueHash(HashOutput::from_slice(value.value_hash)?);
         Ok(Self {
@@ -1075,9 +1079,9 @@ where
 )]
 pub enum PhysicalNode<K> {
     /// A wrapper of [`InternalNode`].
-    Internal(PartialInternalNode),
+    Internal(PhysicalInternalNode),
     /// A wrapper of [`LeafNode`].
-    Leaf(PartialLeafNode<K>),
+    Leaf(PhysicalLeafNode<K>),
     /// Represents empty tree only
     Null,
 }

--- a/jmt/src/types/nibble/mod.rs
+++ b/jmt/src/types/nibble/mod.rs
@@ -17,6 +17,10 @@ use std::fmt;
 // pub const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub struct Nibble(u8);
 
 impl From<u8> for Nibble {

--- a/jmt/src/types/nibble/nibble_path/mod.rs
+++ b/jmt/src/types/nibble/nibble_path/mod.rs
@@ -20,10 +20,14 @@ use crate::errors::CodecError;
 
 use super::Nibble;
 
-#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Debug)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 /// A type-erased [`NibblePath`] with no knowledged of the JMTs digest size.
 /// Useful for creating DB abstractions with fewer generics
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Debug)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(
+    any(test, feature = "borsh"),
+    derive(::borsh::BorshDeserialize, ::borsh::BorshSerialize)
+)]
 pub struct PhysicalNibblePath {
     /// Indicates the total number of nibbles in bytes. Either `bytes.len() * 2 - 1` or
     /// `bytes.len() * 2`.


### PR DESCRIPTION
Allow TreeReader implementers to use anyhow::Errors instead of std::error::Errors. This is necessary to allow any usage of anyhow, since anyhow::Error does not (and cannot) implement the std error trait.

This PR should wait for #30 to merge