### PR TITLE
Draft: Add a new "PhysicalTreeReader" trait for databases

### DIFF
--- a/jmt/src/hash.rs
+++ b/jmt/src/hash.rs
@@ -408,7 +408,9 @@ impl<'a, const N: usize> std::iter::DoubleEndedIterator for HashValueBitIterator
 
 impl<'a, const N: usize> std::iter::ExactSizeIterator for HashValueBitIterator<'a, N> {}
 
-pub trait TreeHash<const N: usize>: std::fmt::Debug + Send + Sync + std::cmp::PartialEq {
+pub trait TreeHash<const N: usize>:
+    std::fmt::Debug + Send + Sync + std::cmp::PartialEq + Clone
+{
     type Hasher: CryptoHasher<N>;
     const SPARSE_MERKLE_PLACEHOLDER_HASH: HashOutput<N>;
     fn hash(data: impl AsRef<[u8]>) -> HashOutput<N> {

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -83,8 +83,7 @@ use errors::CodecError;
 use hash::{HashOutput, HashValueBitIterator, TreeHash};
 use metrics::{inc_deletion_count_if_enabled, set_leaf_count_if_enabled};
 use node_type::{
-    Child, Children, InternalNode, LeafNode, Node, NodeKey, PhysicalLeafNode, PhysicalNode,
-    PhysicalNodeKey,
+    Child, Children, InternalNode, LeafNode, Node, NodeKey, PhysicalNode, PhysicalNodeKey,
 };
 use parallel::{parallel_process_range_if_enabled, run_on_io_pool_if_enabled};
 use proof::{SparseMerkleProof, SparseMerkleProofExt, SparseMerkleRangeProof};
@@ -104,6 +103,8 @@ pub mod mock_tree_store;
 pub mod node_type;
 pub mod parallel;
 pub mod proof;
+mod read_write;
+pub use read_write::*;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test_helper;
 pub mod types;
@@ -132,62 +133,11 @@ pub trait Key:
     fn key_size(&self) -> usize;
 }
 
-/// `TreeReader` defines the interface between
-/// [`JellyfishMerkleTree`](struct.JellyfishMerkleTree.html)
-/// and underlying storage holding nodes.
-pub trait TreeReader<K, H, const N: usize> {
-    type Error: Into<anyhow::Error> + Send + Sync + 'static;
-    /// Gets node given a node key. Returns error if the node does not exist.
-    ///
-    /// Recommended impl:
-    /// ```ignore
-    /// self.get_node_option(node_key)?.ok_or_else(|| Self::Error::from(format!("Missing node at {:?}.", node_key)))
-    /// ```
-    fn get_node(&self, node_key: &NodeKey<N>) -> Result<Node<K, H, N>, Self::Error>;
-
-    /// Gets node given a node key. Returns `None` if the node does not exist.
-    fn get_node_option(&self, node_key: &NodeKey<N>) -> Result<Option<Node<K, H, N>>, Self::Error>;
-
-    /// Gets a value given a key. Returns `None` if the value does not exist.
-    // TODO(@preston-evans98): Make the return type cheaply cloneable
-    fn get_value(&self, key: &(Version, K)) -> Result<Option<Vec<u8>>, Self::Error>;
-
-    /// Gets the rightmost leaf at a version. Note that this assumes we are in the process of
-    /// restoring the tree and all nodes are at the same version.
-    fn get_rightmost_leaf(
-        &self,
-        version: Version,
-    ) -> Result<Option<(NodeKey<N>, LeafNode<K, H, N>)>, Self::Error>;
-}
-
-pub trait PhysicalTreeReader<K> {
-    type Error: Into<anyhow::Error> + Send + Sync + 'static;
-    fn get_physical_node(&self, node_key: &PhysicalNodeKey)
-        -> Result<PhysicalNode<K>, Self::Error>;
-
-    fn get_physical_node_option(
-        &self,
-        node_key: &PhysicalNodeKey,
-    ) -> Result<Option<PhysicalNode<K>>, Self::Error>;
-
-    // TODO(@preston-evans98): Make the return type cheaply cloneable
-    fn get_value(&self, key: &(Version, K)) -> Result<Option<Vec<u8>>, Self::Error>;
-
-    /// Gets the rightmost leaf at a version. Note that this assumes we are in the process of
-    /// restoring the tree and all nodes are at the same version.
-    fn get_rightmost_physical_leaf(
-        &self,
-        version: Version,
-    ) -> Result<Option<(PhysicalNodeKey, PhysicalLeafNode<K>)>, Self::Error>;
-}
-
 /// Node batch that will be written into db atomically with other batches.
 pub type NodeBatch<K, H, const N: usize> = HashMap<NodeKey<N>, Node<K, H, N>>;
 
-pub trait TreeWriter<K, H, const N: usize>: Send + Sync {
-    type Error: std::error::Error + Send + Sync;
-    fn write_node_batch(&self, node_batch: &NodeBatch<K, H, N>) -> Result<(), Self::Error>;
-}
+/// A type-erased batch that will be written into db atomically with other batches.
+pub type PhysicalNodeBatch<K> = HashMap<PhysicalNodeKey, PhysicalNode<K>>;
 
 /// The hash of a key
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord, Debug, Serialize, Deserialize)]

--- a/jmt/src/mock_tree_store.rs
+++ b/jmt/src/mock_tree_store.rs
@@ -64,6 +64,10 @@ where
         Ok(self.data.read().unwrap().0.get(node_key).cloned())
     }
 
+    fn get_value(&self, key: &(Version, K)) -> std::result::Result<Option<Vec<u8>>, Self::Error> {
+        unimplemented!()
+    }
+
     fn get_rightmost_leaf(
         &self,
         version: Version,

--- a/jmt/src/node_type/mod.rs
+++ b/jmt/src/node_type/mod.rs
@@ -44,6 +44,15 @@ pub struct NodeKey<const N: usize> {
     nibble_path: NibblePath<N>,
 }
 
+impl<const N: usize> Into<PhysicalNodeKey> for NodeKey<N> {
+    fn into(self) -> PhysicalNodeKey {
+        PhysicalNodeKey {
+            version: self.version,
+            nibble_path: self.nibble_path.into(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(

--- a/jmt/src/read_write.rs
+++ b/jmt/src/read_write.rs
@@ -1,0 +1,137 @@
+use std::marker::PhantomData;
+
+use crate::{
+    errors::CodecError,
+    node_type::{LeafNode, Node, NodeKey, PhysicalLeafNode, PhysicalNode, PhysicalNodeKey},
+    NodeBatch, PhysicalNodeBatch, Version,
+};
+
+/// `TreeReader` defines the interface between
+/// [`JellyfishMerkleTree`](struct.JellyfishMerkleTree.html)
+/// and underlying storage holding nodes.
+pub trait TreeReader<K, H, const N: usize> {
+    type Error: Into<anyhow::Error> + Send + Sync + 'static;
+    /// Gets node given a node key. Returns error if the node does not exist.
+    ///
+    /// Recommended impl:
+    /// ```ignore
+    /// self.get_node_option(node_key)?.ok_or_else(|| Self::Error::from(format!("Missing node at {:?}.", node_key)))
+    /// ```
+    fn get_node(&self, node_key: &NodeKey<N>) -> Result<Node<K, H, N>, Self::Error>;
+
+    /// Gets node given a node key. Returns `None` if the node does not exist.
+    fn get_node_option(&self, node_key: &NodeKey<N>) -> Result<Option<Node<K, H, N>>, Self::Error>;
+
+    /// Gets a value given a key. Returns `None` if the value does not exist.
+    // TODO(@preston-evans98): Make the return type cheaply cloneable
+    fn get_value(&self, key: &(Version, K)) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Gets the rightmost leaf at a version. Note that this assumes we are in the process of
+    /// restoring the tree and all nodes are at the same version.
+    fn get_rightmost_leaf(
+        &self,
+        version: Version,
+    ) -> Result<Option<(NodeKey<N>, LeafNode<K, H, N>)>, Self::Error>;
+}
+
+pub trait PhysicalTreeReader<K> {
+    type Error: Into<anyhow::Error> + Send + Sync + 'static;
+    fn get_physical_node(&self, node_key: &PhysicalNodeKey)
+        -> Result<PhysicalNode<K>, Self::Error>;
+
+    fn get_physical_node_option(
+        &self,
+        node_key: &PhysicalNodeKey,
+    ) -> Result<Option<PhysicalNode<K>>, Self::Error>;
+
+    // TODO(@preston-evans98): Make the return type cheaply cloneable
+    fn get_value(&self, key: &(Version, K)) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Gets the rightmost leaf at a version. Note that this assumes we are in the process of
+    /// restoring the tree and all nodes are at the same version.
+    fn get_rightmost_physical_leaf(
+        &self,
+        version: Version,
+    ) -> Result<Option<(PhysicalNodeKey, PhysicalLeafNode<K>)>, Self::Error>;
+}
+
+pub trait TreeWriter<K, H, const N: usize>: Send + Sync {
+    type Error: Into<anyhow::Error> + Send + Sync + 'static;
+    fn write_node_batch(&self, node_batch: &NodeBatch<K, H, N>) -> Result<(), Self::Error>;
+}
+
+pub trait PhysicalTreeWriter<K>: Send + Sync {
+    type Error: Into<anyhow::Error> + Send + Sync + 'static;
+    fn write_physical_node_batch(
+        &self,
+        node_batch: &PhysicalNodeBatch<K>,
+    ) -> Result<(), Self::Error>;
+}
+
+/// A typed wrapper around a byte-oriented data store, which automatically converts between
+/// the raw on-disk tree nodes and the typed tree nodes consumed by the JMT
+pub struct TypedStore<T, H, const N: usize> {
+    pub inner: T,
+    _phantom: PhantomData<H>,
+}
+
+impl<T, H, const N: usize> TypedStore<T, H, N> {
+    pub fn new(reader: T) -> Self {
+        Self {
+            inner: reader,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: PhysicalTreeReader<K, Error = E>, E, K, H, const N: usize> TreeReader<K, H, N>
+    for TypedStore<T, H, N>
+where
+    E: Into<anyhow::Error> + From<CodecError> + Send + Sync + 'static,
+{
+    type Error = E;
+
+    fn get_node(&self, node_key: &NodeKey<N>) -> Result<Node<K, H, N>, Self::Error> {
+        let key = node_key.clone().into();
+        let physical_node = self.inner.get_physical_node(&key)?;
+        let node = physical_node.try_into()?;
+        Ok(node)
+    }
+
+    fn get_node_option(&self, node_key: &NodeKey<N>) -> Result<Option<Node<K, H, N>>, Self::Error> {
+        let key = node_key.clone().into();
+        let physical_node_opt = self.inner.get_physical_node_option(&key)?;
+        if let Some(physical_node) = physical_node_opt {
+            let node = physical_node.try_into()?;
+            return Ok(Some(node));
+        }
+        Ok(None)
+    }
+
+    fn get_value(&self, key: &(Version, K)) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.inner.get_value(key)
+    }
+
+    fn get_rightmost_leaf(
+        &self,
+        _version: Version,
+    ) -> Result<Option<(NodeKey<N>, LeafNode<K, H, N>)>, Self::Error> {
+        todo!()
+    }
+}
+
+impl<T: PhysicalTreeWriter<K, Error = E>, E, K: Clone, H: Clone + Send + Sync, const N: usize>
+    TreeWriter<K, H, N> for TypedStore<T, H, N>
+where
+    E: Into<anyhow::Error> + From<CodecError> + Send + Sync + 'static,
+{
+    type Error = E;
+
+    fn write_node_batch(&self, node_batch: &NodeBatch<K, H, N>) -> Result<(), Self::Error> {
+        let physical_node_batch = node_batch
+            .iter()
+            .map(|(k, v)| (k.clone().into(), v.clone().into()))
+            .collect();
+        self.inner.write_physical_node_batch(&physical_node_batch)
+    }
+}

--- a/jmt/src/types/nibble/nibble_path/mod.rs
+++ b/jmt/src/types/nibble/nibble_path/mod.rs
@@ -64,6 +64,12 @@ impl<const N: usize> TryFrom<PhysicalNibblePath> for NibblePath<N> {
 #[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct NibblePath<const N: usize>(PhysicalNibblePath);
 
+impl<const N: usize> Into<PhysicalNibblePath> for NibblePath<N> {
+    fn into(self) -> PhysicalNibblePath {
+        self.0
+    }
+}
+
 /// Supports debug format by concatenating nibbles literally. For example, [0x12, 0xa0] with 3
 /// nibbles will be printed as "12a".
 impl<const N: usize> fmt::Debug for NibblePath<N> {


### PR DESCRIPTION
Add a new trait `PhysicalTreeReader` which is suitable for use at the database layer. It is unaware of the hash function used by the JMT, but stores all of they physical bits of each node.

