### PR TITLE
Basic integration tests for `sov-modules-impl`

### DIFF
--- a/jmt/src/mock_tree_store.rs
+++ b/jmt/src/mock_tree_store.rs
@@ -18,6 +18,7 @@ use std::{
 pub struct MemTreeStore<K> {
     data: RwLock<HashMap<PhysicalNodeKey, PhysicalNode<K>>>,
 }
+
 pub struct MockTreeStore<K, H, const N: usize> {
     /// A redundant TreeReader implementation to test out the TypedStore struct
     wrapped_physical_store: TypedStore<MemTreeStore<K>, H, N>,

--- a/jmt/src/mock_tree_store.rs
+++ b/jmt/src/mock_tree_store.rs
@@ -18,7 +18,6 @@ use std::{
 pub struct MemTreeStore<K> {
     data: RwLock<HashMap<PhysicalNodeKey, PhysicalNode<K>>>,
 }
-
 pub struct MockTreeStore<K, H, const N: usize> {
     /// A redundant TreeReader implementation to test out the TypedStore struct
     wrapped_physical_store: TypedStore<MemTreeStore<K>, H, N>,

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -10,6 +10,9 @@ use sovereign_sdk::{
 };
 use std::{convert::Infallible, io::Read};
 
+// separator == "/"
+const DOMAIN_SEPARATOR: [u8; 1] = [47];
+
 // A unique identifier for each state variable in a module.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Prefix {
@@ -31,19 +34,19 @@ impl Prefix {
 impl From<Prefix> for sov_state::Prefix {
     fn from(prefix: Prefix) -> Self {
         let mut combined_prefix = Vec::with_capacity(
-            prefix.module_path.len() + prefix.module_name.len() + prefix.storage_name.len() + 3,
+            prefix.module_path.len()
+                + prefix.module_name.len()
+                + prefix.storage_name.len()
+                + 3 * DOMAIN_SEPARATOR.len(),
         );
-
-        // separator == "/""
-        let separator = [47];
 
         // We call this logic only once per module instantiation, so we don't have to use AlignedVec here.
         combined_prefix.extend(prefix.module_path.as_bytes());
-        combined_prefix.extend(separator);
+        combined_prefix.extend(DOMAIN_SEPARATOR);
         combined_prefix.extend(prefix.module_name.as_bytes());
-        combined_prefix.extend(separator);
+        combined_prefix.extend(DOMAIN_SEPARATOR);
         combined_prefix.extend(prefix.storage_name.as_bytes());
-        combined_prefix.extend(separator);
+        combined_prefix.extend(DOMAIN_SEPARATOR);
         sov_state::Prefix::new(combined_prefix)
     }
 }

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -5,7 +5,7 @@ pub mod mocks;
 
 use sov_state::Storage;
 use sovereign_sdk::{
-    serial::{Decode, DecodeBorrowed},
+    serial::{Decode, DecodeBorrowed, Encode},
     stf::Event,
 };
 use std::{convert::Infallible, io::Read};
@@ -31,12 +31,18 @@ impl Prefix {
 impl From<Prefix> for sov_state::Prefix {
     fn from(prefix: Prefix) -> Self {
         let mut combined_prefix = Vec::with_capacity(
-            prefix.module_path.len() + prefix.module_name.len() + prefix.storage_name.len(),
+            prefix.module_path.len() + prefix.module_name.len() + prefix.storage_name.len() + 3,
         );
 
+        // separator == "/""
+        let separator = [47];
+
         combined_prefix.extend(prefix.module_path.as_bytes());
+        combined_prefix.extend(separator);
         combined_prefix.extend(prefix.module_name.as_bytes());
+        combined_prefix.extend(separator);
         combined_prefix.extend(prefix.storage_name.as_bytes());
+        combined_prefix.extend(separator);
         sov_state::Prefix::new(combined_prefix)
     }
 }
@@ -55,7 +61,7 @@ impl From<Infallible> for DecodingError {
 pub trait Context {
     type Storage: Storage + Clone;
     type Signature: Decode;
-    type PublicKey: Decode + Eq;
+    type PublicKey: Decode + Encode + Eq;
 
     // Sender of the transaction.
     fn sender(&self) -> &Self::PublicKey;

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -37,7 +37,7 @@ impl From<Prefix> for sov_state::Prefix {
         // separator == "/""
         let separator = [47];
 
-        // We call this logic for every state variable but only once per module instantiation, so not padding the vecs should be fine.
+        // We call this logic only once per module instantiation, so we don't have to use AlignedVec here.
         combined_prefix.extend(prefix.module_path.as_bytes());
         combined_prefix.extend(separator);
         combined_prefix.extend(prefix.module_name.as_bytes());

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -37,6 +37,7 @@ impl From<Prefix> for sov_state::Prefix {
         // separator == "/""
         let separator = [47];
 
+        // We call this logic for every state variable but only once per module instantiation, so not padding the vecs should be fine.
         combined_prefix.extend(prefix.module_path.as_bytes());
         combined_prefix.extend(separator);
         combined_prefix.extend(prefix.module_name.as_bytes());

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -1,9 +1,9 @@
 use crate::Context;
 use sov_state::storage::{StorageKey, StorageValue};
-use std::{collections::HashMap, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 
 /// Mock for Context::PublicKey, useful for testing.
-#[derive(borsh::BorshDeserialize, PartialEq, Eq)]
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, PartialEq, Eq)]
 pub struct MockPublicKey {
     pub_key: Vec<u8>,
 }
@@ -29,24 +29,25 @@ impl MockSignature {
 /// Mock for Context::Storage, useful for testing.
 // TODO: as soon as we have JMT storage implemented, we should remove this mock and use a real db even in tests.
 // see https://github.com/Sovereign-Labs/sovereign/issues/40
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct MockStorage {
-    storage: HashMap<Arc<Vec<u8>>, Arc<Vec<u8>>>,
+    pub storage: Rc<RefCell<HashMap<Arc<Vec<u8>>, Arc<Vec<u8>>>>>,
 }
 
 impl sov_state::Storage for MockStorage {
-    fn get(&mut self, key: StorageKey, _version: u64) -> Option<StorageValue> {
+    fn get(&self, key: StorageKey) -> Option<StorageValue> {
         self.storage
+            .borrow()
             .get(&key.key)
             .map(|v| StorageValue { value: v.clone() })
     }
 
-    fn set(&mut self, key: StorageKey, _version: u64, value: StorageValue) {
-        self.storage.insert(key.key, value.value);
+    fn set(&self, key: StorageKey, value: StorageValue) {
+        self.storage.borrow_mut().insert(key.key, value.value);
     }
 
-    fn delete(&mut self, key: StorageKey, _version: u64) {
-        self.storage.remove(&key.key);
+    fn delete(&self, key: StorageKey) {
+        self.storage.borrow_mut().remove(&key.key);
     }
 }
 

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -38,16 +38,16 @@ impl sov_state::Storage for MockStorage {
     fn get(&self, key: StorageKey) -> Option<StorageValue> {
         self.storage
             .borrow()
-            .get(&key.key)
+            .get(key.as_ref())
             .map(|v| StorageValue { value: v.clone() })
     }
 
     fn set(&self, key: StorageKey, value: StorageValue) {
-        self.storage.borrow_mut().insert(key.key, value.value);
+        self.storage.borrow_mut().insert(key.key(), value.value);
     }
 
     fn delete(&self, key: StorageKey) {
-        self.storage.borrow_mut().remove(&key.key);
+        self.storage.borrow_mut().remove(&key.key());
     }
 }
 

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -26,12 +26,14 @@ impl MockSignature {
     }
 }
 
+type Storage = Rc<RefCell<HashMap<Arc<Vec<u8>>, Arc<Vec<u8>>>>>;
+
 /// Mock for Context::Storage, useful for testing.
 // TODO: as soon as we have JMT storage implemented, we should remove this mock and use a real db even in tests.
 // see https://github.com/Sovereign-Labs/sovereign/issues/40
 #[derive(Clone, Default, Debug)]
 pub struct MockStorage {
-    pub storage: Rc<RefCell<HashMap<Arc<Vec<u8>>, Arc<Vec<u8>>>>>,
+    storage: Storage,
 }
 
 impl sov_state::Storage for MockStorage {
@@ -42,11 +44,11 @@ impl sov_state::Storage for MockStorage {
             .map(|v| StorageValue { value: v.clone() })
     }
 
-    fn set(&self, key: StorageKey, value: StorageValue) {
+    fn set(&mut self, key: StorageKey, value: StorageValue) {
         self.storage.borrow_mut().insert(key.key(), value.value);
     }
 
-    fn delete(&self, key: StorageKey) {
+    fn delete(&mut self, key: StorageKey) {
         self.storage.borrow_mut().remove(&key.key());
     }
 }

--- a/sov-modules/sov-modules-impl/Cargo.toml
+++ b/sov-modules/sov-modules-impl/Cargo.toml
@@ -3,6 +3,9 @@ name = "sov-modules-impl"
 version = "0.1.0"
 edition = "2021"
 
+[dev-dependencies]
+sov-modules-api = { workspace = true ,  features = ["mocks"]}
+
 [dependencies]
 sov-modules-api = { workspace = true }
 sov-modules-macros = { workspace = true }

--- a/sov-modules/sov-modules-impl/src/example/call.rs
+++ b/sov-modules/sov-modules-impl/src/example/call.rs
@@ -2,7 +2,7 @@ use super::{Bank, Delete, Transfer};
 
 impl<C: sov_modules_api::Context> Bank<C> {
     pub(crate) fn do_transfer(
-        &mut self,
+        &self,
         transfer: Transfer<C>,
         context: C,
     ) -> Result<sov_modules_api::CallResponse, <Self as sov_modules_api::Module>::CallError> {

--- a/sov-modules/sov-modules-impl/src/example/mod.rs
+++ b/sov-modules/sov-modules-impl/src/example/mod.rs
@@ -2,7 +2,7 @@ mod call;
 mod query;
 
 use sov_modules_macros::ModuleInfo;
-use sovereign_sdk::serial::{Decode, DecodeBorrowed};
+use sovereign_sdk::serial::{Decode, DecodeBorrowed, Encode};
 
 pub struct AccountData {}
 
@@ -75,6 +75,30 @@ impl<C: sov_modules_api::Context> Decode for CallMessage<C> {
     type Error = CustomError;
 
     fn decode<R: std::io::Read>(_: &mut R) -> Result<Self, <Self as Decode>::Error> {
+        todo!()
+    }
+}
+
+// Generated
+impl Encode for AccountData {
+    fn encode(&self, _target: &mut impl std::io::Write) {
+        todo!()
+    }
+}
+
+impl<'de> DecodeBorrowed<'de> for AccountData {
+    type Error = ();
+
+    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+// Generated
+impl Decode for AccountData {
+    type Error = ();
+
+    fn decode<R: std::io::Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
         todo!()
     }
 }

--- a/sov-modules/sov-modules-impl/src/example/mod.rs
+++ b/sov-modules/sov-modules-impl/src/example/mod.rs
@@ -86,6 +86,7 @@ impl Encode for AccountData {
     }
 }
 
+// Generated
 impl<'de> DecodeBorrowed<'de> for AccountData {
     type Error = ();
 

--- a/sov-modules/sov-modules-impl/src/example/mod.rs
+++ b/sov-modules/sov-modules-impl/src/example/mod.rs
@@ -89,7 +89,7 @@ impl Encode for AccountData {
 impl<'de> DecodeBorrowed<'de> for AccountData {
     type Error = ();
 
-    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+    fn decode_from_slice(_target: &'de [u8]) -> Result<Self, Self::Error> {
         todo!()
     }
 }
@@ -98,7 +98,7 @@ impl<'de> DecodeBorrowed<'de> for AccountData {
 impl Decode for AccountData {
     type Error = ();
 
-    fn decode<R: std::io::Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
+    fn decode<R: std::io::Read>(_target: &mut R) -> Result<Self, <Self as Decode>::Error> {
         todo!()
     }
 }

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -14,7 +14,7 @@ pub mod module_a {
     }
 
     impl<C: Context> ModuleA<C> {
-        pub fn update(&self, key: &str, value: &str) {
+        pub fn update(&mut self, key: &str, value: &str) {
             self.state_1_a.set(key.to_owned(), value.to_owned())
         }
     }
@@ -33,7 +33,7 @@ pub mod module_b {
     }
 
     impl<C: Context> ModuleB<C> {
-        pub fn update(&self, key: &str, value: &str) {
+        pub fn update(&mut self, key: &str, value: &str) {
             self.state_1_b.set(key.to_owned(), value.to_owned());
             self.mod_1_a.update("key_from_b", value);
         }
@@ -53,7 +53,7 @@ mod module_c {
     }
 
     impl<C: Context> ModuleC<C> {
-        pub fn update(&self, key: &str, value: &str) {
+        pub fn update(&mut self, key: &str, value: &str) {
             self.mod_1_a.update(key, value);
             self.mod_1_b.update(key, value);
             self.mod_1_a.update(key, value);

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -1,8 +1,9 @@
 use sov_modules_api::mocks::{MockContext, MockStorage};
 use sov_modules_api::{Context, Prefix};
 use sov_modules_macros::ModuleInfo;
-use sov_state::storage::StorageKey;
+use sov_state::storage::{StorageKey, StorageValue};
 use sov_state::{StateMap, Storage};
+use sovereign_sdk::serial::{Decode, Encode};
 
 pub mod module_a {
     use super::*;
@@ -68,6 +69,10 @@ fn test() {
 
     module.update("key", "some_value");
 
+    //  "".encode(target)
+    //let s = String::decode("some_value")
+    let value = StorageValue::from("some_value");
+
     {
         let prefix = Prefix::new(
             "tests::module_a".to_owned(),
@@ -77,6 +82,7 @@ fn test() {
 
         let key = StorageKey::new(&prefix.into(), "key");
         let v = test_storage.get(key).unwrap();
+        assert_eq!(value, v);
     }
 
     {
@@ -88,6 +94,7 @@ fn test() {
 
         let key = StorageKey::new(&prefix.into(), "key");
         let v = test_storage.get(key).unwrap();
+        assert_eq!(value, v);
     }
 
     {
@@ -99,5 +106,6 @@ fn test() {
 
         let key = StorageKey::new(&prefix.into(), "insert_from_c");
         let v = test_storage.get(key).unwrap();
+        assert_eq!(value, v);
     }
 }

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+
+use sov_modules_api::mocks::{MockContext, MockStorage};
+use sov_modules_api::Context;
+use sov_modules_macros::ModuleInfo;
+use sov_state::storage::{StorageKey, StorageValue};
+use sov_state::{StateMap, Storage};
+use sovereign_sdk::serial::Decode;
+
+pub mod module_a {
+    use super::*;
+
+    #[derive(ModuleInfo)]
+    pub(crate) struct ModuleA<C: Context> {
+        #[state]
+        state_1_a: StateMap<String, String, C::Storage>,
+    }
+
+    impl<C: Context> ModuleA<C> {
+        pub fn update(&self, key: &str, value: &str) {
+            self.state_1_a.set(key.to_owned(), value.to_owned())
+        }
+    }
+}
+
+pub mod module_b {
+    use super::*;
+
+    #[derive(ModuleInfo)]
+    pub(crate) struct ModuleB<C: Context> {
+        #[state]
+        state_1_b: StateMap<String, String, C::Storage>,
+
+        #[module]
+        mod_1_a: module_a::ModuleA<C>,
+    }
+
+    impl<C: Context> ModuleB<C> {
+        pub fn update(&self, key: &str, value: &str) {
+            //   self.state_1_b.set(key.to_owned(), value.to_owned());
+            self.mod_1_a.update("insert_from_c", value);
+        }
+    }
+}
+
+mod module_c {
+    use super::*;
+
+    #[derive(ModuleInfo)]
+    pub(crate) struct ModuleC<C: Context> {
+        #[module]
+        mod_1_a: module_a::ModuleA<C>,
+
+        #[module]
+        mod_1_b: module_b::ModuleB<C>,
+    }
+
+    impl<C: Context> ModuleC<C> {
+        pub fn update(&self, key: &str, value: &str) {
+            self.mod_1_a.update(key, value);
+            self.mod_1_b.update(key, value);
+            //    self.mod_1_a.update(key, value);
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let test_storage = MockStorage::default();
+    let module = &mut module_c::ModuleC::<MockContext>::_new(test_storage.clone());
+
+    module.update("key", "some_value");
+
+    for (k, v) in test_storage.storage.borrow().iter() {
+        let mut ll: &[u8] = k;
+
+        let key = String::decode(&mut ll);
+
+        println!("{:?}", key);
+
+        //  let mut ll: &[u8] = v;
+        //  let x = String::decode(&mut ll);
+        //  println!("{:?}", x);
+    }
+
+    let key = StorageKey::from("tests::module_a/ModuleA/state_1_a/key");
+
+    let v = test_storage.get(key);
+    println!("{:?}", v);
+    /*
+    let key1 = StorageKey {
+        key: Arc::new("tests::module_a/ModuleA/state_1_a/key".as_bytes().to_vec()),
+    };
+
+    let value = StorageValue {
+        value: Arc::new("some_value".as_bytes().to_vec()),
+    };
+
+    let g = test_storage.get(key1);
+    let mut g = g.clone().unwrap();
+    let v: Arc<Vec<u8>> = g.value;
+
+    let mut ll: &[u8] = &v;
+
+    let x = String::decode(&mut ll);
+
+    println!("{:?}", x);
+
+    let yy = "/";
+
+    println!("{:?}", yy.as_bytes());
+
+    */
+}

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -68,7 +68,7 @@ fn nested_module_call_test() {
 
     let expected_value = StorageValue::new("some_value");
 
-    // TODO remove all .to_owned() calls;
+    // TODO remove all ".to_owned()" calls;
     // https://github.com/Sovereign-Labs/sovereign/issues/46
     {
         let prefix = Prefix::new(

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# TODO remove this dependency once the  Decode/Encode traits are extracted to a separate crate.
 sovereign-sdk = { workspace = true }
 first-read-last-write-cache = { workspace = true }
 jellyfish-merkle-generic = { workspace = true }

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+sovereign-sdk = { workspace = true }
 first-read-last-write-cache = { workspace = true }
 jellyfish-merkle-generic = { workspace = true }
 

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -6,18 +6,19 @@ use jellyfish_merkle_generic::Version;
 pub struct JmtStorage {
     // Caches first read and last write for a particular key.
     _cache: CacheLog,
+    _version: Version,
 }
 
 impl Storage for JmtStorage {
-    fn get(&mut self, _key: StorageKey, _version: Version) -> Option<StorageValue> {
+    fn get(&self, _key: StorageKey) -> Option<StorageValue> {
         todo!()
     }
 
-    fn set(&mut self, _key: StorageKey, _version: Version, _value: StorageValue) {
+    fn set(&self, _key: StorageKey, _value: StorageValue) {
         todo!()
     }
 
-    fn delete(&mut self, _key: StorageKey, _version: u64) {
+    fn delete(&self, _key: StorageKey) {
         todo!()
     }
 }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -14,11 +14,11 @@ impl Storage for JmtStorage {
         todo!()
     }
 
-    fn set(&self, _key: StorageKey, _value: StorageValue) {
+    fn set(&mut self, _key: StorageKey, _value: StorageValue) {
         todo!()
     }
 
-    fn delete(&self, _key: StorageKey) {
+    fn delete(&mut self, _key: StorageKey) {
         todo!()
     }
 }

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -1,10 +1,12 @@
 mod jmt_storage;
 mod map;
 pub mod storage;
+mod utils;
 
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;
+use utils::AlignedVec;
 
 // A prefix prepended to each key before insertion and retrieval from the storage.
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
@@ -12,15 +14,17 @@ pub use storage::Storage;
 // prefix that is prepended to each key.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Prefix {
-    prefix: Vec<u8>,
+    prefix: AlignedVec,
 }
 
 impl Prefix {
     pub fn new(prefix: Vec<u8>) -> Self {
-        Self { prefix }
+        Self {
+            prefix: AlignedVec::new(prefix),
+        }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_aligned_vec(&self) -> &AlignedVec {
         &self.prefix
     }
 

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -27,4 +27,9 @@ impl Prefix {
     pub fn len(&self) -> usize {
         self.prefix.len()
     }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -19,4 +19,12 @@ impl Prefix {
     pub fn new(prefix: Vec<u8>) -> Self {
         Self { prefix }
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.prefix
+    }
+
+    pub fn len(&self) -> usize {
+        self.prefix.len()
+    }
 }

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -54,19 +54,6 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     }
 
     fn make_full_key(&self, key: K) -> StorageKey {
-        let mut encoded_key = Vec::default();
-        key.encode(&mut encoded_key);
-
-        let mut full_key = Vec::<u8>::default();
-        full_key.extend(self.prefix.as_bytes());
-        full_key.extend(encoded_key);
-
-        let mut encoded_full_key = Vec::default();
-
-        full_key.encode(&mut encoded_full_key);
-
-        StorageKey {
-            key: Arc::new(encoded_full_key),
-        }
+        StorageKey::new(&self.prefix, key)
     }
 }

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -1,4 +1,7 @@
-use crate::{storage::StorageKey, Prefix, Storage};
+use crate::{
+    storage::{StorageKey, StorageValue},
+    Prefix, Storage,
+};
 use sovereign_sdk::serial::{Decode, Encode};
 use std::marker::PhantomData;
 
@@ -24,8 +27,7 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     // Inserts a key-value pair into the map.
     pub fn set(&self, key: K, value: V) {
         let storage_key = StorageKey::new(&self.prefix, key);
-
-        let storage_value = value.into();
+        let storage_value = StorageValue::new(value);
         self.storage.set(storage_key, storage_value);
     }
 

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -37,24 +37,18 @@ impl StorageKey {
     }
 }
 
-impl From<&'static str> for StorageKey {
-    fn from(value: &'static str) -> Self {
-        Self {
-            key: Arc::new(value.as_bytes().to_vec()),
-        }
-    }
-}
-
 // `Value` type for the `Storage`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StorageValue {
     pub value: Arc<Vec<u8>>,
 }
 
-impl From<&'static str> for StorageValue {
-    fn from(value: &'static str) -> Self {
+impl<T: Encode> From<T> for StorageValue {
+    fn from(value: T) -> Self {
+        let mut encoded_value = Vec::default();
+        value.encode(&mut encoded_value);
         Self {
-            value: Arc::new(value.as_bytes().to_vec()),
+            value: Arc::new(encoded_value),
         }
     }
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -6,20 +6,36 @@ pub struct StorageKey {
     pub key: Arc<Vec<u8>>,
 }
 
+impl From<&'static str> for StorageKey {
+    fn from(value: &'static str) -> Self {
+        Self {
+            key: Arc::new(value.as_bytes().to_vec()),
+        }
+    }
+}
+
 // `Value` type for the `Storage`
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StorageValue {
     pub value: Arc<Vec<u8>>,
+}
+
+impl From<&'static str> for StorageValue {
+    fn from(value: &'static str) -> Self {
+        Self {
+            value: Arc::new(value.as_bytes().to_vec()),
+        }
+    }
 }
 
 // An interface for storing and retrieving values in the storage.
 pub trait Storage {
     // Returns the value corresponding to the key or None if key is absent.
-    fn get(&mut self, key: StorageKey, version: u64) -> Option<StorageValue>;
+    fn get(&self, key: StorageKey) -> Option<StorageValue>;
 
     // Inserts a key-value pair into the storage.
-    fn set(&mut self, key: StorageKey, version: u64, value: StorageValue);
+    fn set(&self, key: StorageKey, value: StorageValue);
 
     // Deletes a key from the storage.
-    fn delete(&mut self, key: StorageKey, version: u64);
+    fn delete(&self, key: StorageKey);
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -23,15 +23,15 @@ impl AsRef<Vec<u8>> for StorageKey {
 }
 
 impl StorageKey {
+    // Creates a new prefixed StorageKey.
     pub fn new<K: Encode>(prefix: &Prefix, key: K) -> Self {
         let mut encoded_key = Vec::default();
         key.encode(&mut encoded_key);
 
         let encoded_key = AlignedVec::new(encoded_key);
 
-        let mut full_key =
-            AlignedVec::new(Vec::<u8>::with_capacity(prefix.len() + encoded_key.len()));
-
+        let full_key = Vec::<u8>::with_capacity(prefix.len() + encoded_key.len());
+        let mut full_key = AlignedVec::new(full_key);
         full_key.extend(prefix.as_aligned_vec());
         full_key.extend(&encoded_key);
 
@@ -63,8 +63,8 @@ pub trait Storage {
     fn get(&self, key: StorageKey) -> Option<StorageValue>;
 
     // Inserts a key-value pair into the storage.
-    fn set(&self, key: StorageKey, value: StorageValue);
+    fn set(&mut self, key: StorageKey, value: StorageValue);
 
     // Deletes a key from the storage.
-    fn delete(&self, key: StorageKey);
+    fn delete(&mut self, key: StorageKey);
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -1,9 +1,40 @@
 use std::sync::Arc;
 
+use sovereign_sdk::serial::Encode;
+
+use crate::Prefix;
+
 // `Key` type for the `Storage`
 #[derive(Clone, PartialEq, Eq)]
 pub struct StorageKey {
-    pub key: Arc<Vec<u8>>,
+    key: Arc<Vec<u8>>,
+}
+
+impl StorageKey {
+    pub fn key(&self) -> Arc<Vec<u8>> {
+        self.key.clone()
+    }
+}
+
+impl AsRef<Vec<u8>> for StorageKey {
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.key
+    }
+}
+
+impl StorageKey {
+    pub fn new<K: Encode>(prefix: &Prefix, key: K) -> Self {
+        let mut encoded_key = Vec::default();
+        key.encode(&mut encoded_key);
+
+        let mut full_key = Vec::<u8>::default();
+        full_key.extend(prefix.as_bytes());
+        full_key.extend(encoded_key);
+
+        Self {
+            key: Arc::new(full_key),
+        }
+    }
 }
 
 impl From<&'static str> for StorageKey {

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -16,7 +16,7 @@ impl AlignedVec {
 
     // Extends self with the contents of the other AlignedVec.
     pub fn extend(&mut self, other: &Self) {
-        // TODO check if the standard extend method do the right thing on
+        // TODO check if the standard extend method does the right thing.
         self.inner.extend(&other.inner);
     }
 

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, PartialEq, Eq)]
+pub struct AlignedVec {
+    inner: Vec<u8>,
+}
+
+impl AlignedVec {
+    pub fn new(vector: Vec<u8>) -> Self {
+        Self { inner: vector }
+    }
+
+    pub fn extend(&mut self, other: &Self) {
+        self.inner.extend(&other.inner);
+    }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl AsRef<Vec<u8>> for AlignedVec {
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.inner
+    }
+}

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -1,14 +1,22 @@
+// AlignedVec keeps a vec whose length is guaranteed to be aligned to 4 bytes.
+// This makes certain operations cheaper in zk-context (concatenation)
+// TODO: Currently the implementation defaults to `stc::vec::Vec` see:
+// https://github.com/Sovereign-Labs/sovereign/issues/47
 #[derive(Debug, PartialEq, Eq)]
 pub struct AlignedVec {
     inner: Vec<u8>,
 }
 
 impl AlignedVec {
+    // Creates a new AlignedVec whose length is aligned to 4 bytes.
     pub fn new(vector: Vec<u8>) -> Self {
+        // TODO pad the vector to
         Self { inner: vector }
     }
 
+    // Extends self with the contents of the other AlignedVec.
     pub fn extend(&mut self, other: &Self) {
+        // TODO check if the standard extend method do the right thing on
         self.inner.extend(&other.inner);
     }
 


### PR DESCRIPTION
This PR introduces the following changes:
1. Basic integration tests in `sov-modules-impl`.
2. Logic for `pferix` and `state_key` concatentation.
3. Code stub for `AlignedVec `
4. Implementations for `get/set in StateMap`

close #35