### PR TITLE
Add StateValue type to storage

### DIFF
--- a/first-read-last-write-cache/src/lib.rs
+++ b/first-read-last-write-cache/src/lib.rs
@@ -24,6 +24,12 @@ pub struct CacheValue {
     pub value: Option<Arc<Vec<u8>>>,
 }
 
+impl CacheValue {
+    pub fn empty() -> Self {
+        Self { value: None }
+    }
+}
+
 impl Display for CacheValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO revisit how we display values

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -1,6 +1,5 @@
 use crate::Context;
-use sov_state::storage::{StorageKey, StorageValue};
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+use sov_state::JmtStorage;
 
 /// Mock for Context::PublicKey, useful for testing.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, PartialEq, Eq)]
@@ -26,40 +25,13 @@ impl MockSignature {
     }
 }
 
-type Storage = Rc<RefCell<HashMap<Arc<Vec<u8>>, Arc<Vec<u8>>>>>;
-
-/// Mock for Context::Storage, useful for testing.
-// TODO: as soon as we have JMT storage implemented, we should remove this mock and use a real db even in tests.
-// see https://github.com/Sovereign-Labs/sovereign/issues/40
-#[derive(Clone, Default, Debug)]
-pub struct MockStorage {
-    storage: Storage,
-}
-
-impl sov_state::Storage for MockStorage {
-    fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.storage
-            .borrow()
-            .get(key.as_ref())
-            .map(|v| StorageValue { value: v.clone() })
-    }
-
-    fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.storage.borrow_mut().insert(key.key(), value.value);
-    }
-
-    fn delete(&mut self, key: StorageKey) {
-        self.storage.borrow_mut().remove(&key.key());
-    }
-}
-
 /// Mock for Context, useful for testing.
 pub struct MockContext {
     sender: MockPublicKey,
 }
 
 impl Context for MockContext {
-    type Storage = MockStorage;
+    type Storage = JmtStorage;
 
     type Signature = MockSignature;
 

--- a/sov-modules/sov-modules-impl/src/lib.rs
+++ b/sov-modules/sov-modules-impl/src/lib.rs
@@ -1,5 +1,4 @@
 use sov_modules_api::Module;
-
 mod example;
 
 pub struct Transaction<C: sov_modules_api::Context> {

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -1,8 +1,9 @@
+
 use sov_modules_api::mocks::MockContext;
 use sov_modules_api::{Context, Prefix};
 use sov_modules_macros::ModuleInfo;
 use sov_state::storage::{StorageKey, StorageValue};
-use sov_state::{JmtStorage, StateMap, Storage};
+use sov_state::{JmtStorage, SingletonKey, StateMap, StateValue, Storage};
 
 pub mod module_a {
     use super::*;
@@ -11,11 +12,15 @@ pub mod module_a {
     pub(crate) struct ModuleA<C: Context> {
         #[state]
         state_1_a: StateMap<String, String, C::Storage>,
+
+        #[state]
+        state_2_a: StateValue<String, C::Storage>,
     }
 
     impl<C: Context> ModuleA<C> {
         pub fn update(&mut self, key: &str, value: &str) {
-            self.state_1_a.set(key.to_owned(), value.to_owned())
+            self.state_1_a.set(key.to_owned(), value.to_owned());
+            self.state_2_a.set(value.to_owned())
         }
     }
 }
@@ -87,6 +92,14 @@ fn nested_module_call_test() {
     {
         let prefix = Prefix::new("tests::module_a", "ModuleA", "state_1_a");
         let key = StorageKey::new(&prefix.into(), "key_from_b");
+        let value = test_storage.get(key).unwrap();
+
+        assert_eq!(expected_value, value);
+    }
+
+    {
+        let prefix = Prefix::new("tests::module_a", "ModuleA", "state_2_a");
+        let key = StorageKey::new(&prefix.into(), SingletonKey);
         let value = test_storage.get(key).unwrap();
 
         assert_eq!(expected_value, value);

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -1,8 +1,8 @@
-use sov_modules_api::mocks::{MockContext, MockStorage};
+use sov_modules_api::mocks::MockContext;
 use sov_modules_api::{Context, Prefix};
 use sov_modules_macros::ModuleInfo;
 use sov_state::storage::{StorageKey, StorageValue};
-use sov_state::{StateMap, Storage};
+use sov_state::{JmtStorage, StateMap, Storage};
 
 pub mod module_a {
     use super::*;
@@ -62,7 +62,7 @@ mod module_c {
 }
 #[test]
 fn nested_module_call_test() {
-    let test_storage = MockStorage::default();
+    let test_storage = JmtStorage::default();
     let module = &mut module_c::ModuleC::<MockContext>::_new(test_storage.clone());
     module.update("some_key", "some_value");
 

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -1,9 +1,8 @@
-
 use sov_modules_api::mocks::MockContext;
 use sov_modules_api::{Context, Prefix};
 use sov_modules_macros::ModuleInfo;
 use sov_state::storage::{StorageKey, StorageValue};
-use sov_state::{JmtStorage, SingletonKey, StateMap, StateValue, Storage};
+use sov_state::{JmtStorage, StateMap, StateValue, Storage};
 
 pub mod module_a {
     use super::*;
@@ -11,10 +10,10 @@ pub mod module_a {
     #[derive(ModuleInfo)]
     pub(crate) struct ModuleA<C: Context> {
         #[state]
-        state_1_a: StateMap<String, String, C::Storage>,
+        pub(crate) state_1_a: StateMap<String, String, C::Storage>,
 
         #[state]
-        state_2_a: StateValue<String, C::Storage>,
+        pub(crate) state_2_a: StateValue<String, C::Storage>,
     }
 
     impl<C: Context> ModuleA<C> {
@@ -34,7 +33,7 @@ pub mod module_b {
         state_1_b: StateMap<String, String, C::Storage>,
 
         #[module]
-        mod_1_a: module_a::ModuleA<C>,
+        pub(crate) mod_1_a: module_a::ModuleA<C>,
     }
 
     impl<C: Context> ModuleB<C> {
@@ -51,7 +50,7 @@ mod module_c {
     #[derive(ModuleInfo)]
     pub(crate) struct ModuleC<C: Context> {
         #[module]
-        mod_1_a: module_a::ModuleA<C>,
+        pub(crate) mod_1_a: module_a::ModuleA<C>,
 
         #[module]
         mod_1_b: module_b::ModuleB<C>,
@@ -98,10 +97,7 @@ fn nested_module_call_test() {
     }
 
     {
-        let prefix = Prefix::new("tests::module_a", "ModuleA", "state_2_a");
-        let key = StorageKey::new(&prefix.into(), SingletonKey);
-        let value = test_storage.get(key).unwrap();
-
-        assert_eq!(expected_value, value);
+        let value = module.mod_1_a.state_2_a.get().unwrap();
+        assert_eq!("some_value".to_owned(), value);
     }
 }

--- a/sov-modules/sov-modules-macros/tests/mod_and_state.rs
+++ b/sov-modules/sov-modules-macros/tests/mod_and_state.rs
@@ -1,7 +1,7 @@
-use sov_modules_api::mocks::{MockContext, MockStorage};
+use sov_modules_api::mocks::MockContext;
 use sov_modules_api::Context;
 use sov_modules_macros::ModuleInfo;
-use sov_state::StateMap;
+use sov_state::{JmtStorage, StateMap};
 
 pub mod first_test_module {
     use super::*;
@@ -30,7 +30,7 @@ mod second_test_module {
 }
 
 fn main() {
-    let test_storage = MockStorage::default();
+    let test_storage = JmtStorage::default();
 
     let second_test_struct =
         second_test_module::SecondTestStruct::<MockContext>::_new(test_storage);

--- a/sov-modules/sov-modules-macros/tests/parse.rs
+++ b/sov-modules/sov-modules-macros/tests/parse.rs
@@ -1,7 +1,7 @@
-use sov_modules_api::mocks::{MockContext, MockStorage};
+use sov_modules_api::mocks::MockContext;
 use sov_modules_api::Context;
 use sov_modules_macros::ModuleInfo;
-use sov_state::StateMap;
+use sov_state::{JmtStorage, StateMap};
 
 mod test_module {
     use super::*;
@@ -17,7 +17,7 @@ mod test_module {
 }
 
 fn main() {
-    let test_storage = MockStorage::default();
+    let test_storage = JmtStorage::default();
     let test_struct = test_module::TestStruct::<MockContext>::_new(test_storage);
 
     let prefix1 = test_struct.test_state1.prefix();

--- a/sov-modules/sov-modules-macros/tests/parse.rs
+++ b/sov-modules/sov-modules-macros/tests/parse.rs
@@ -1,7 +1,7 @@
 use sov_modules_api::mocks::MockContext;
 use sov_modules_api::Context;
 use sov_modules_macros::ModuleInfo;
-use sov_state::{JmtStorage, StateMap};
+use sov_state::{JmtStorage, StateMap, StateValue};
 
 mod test_module {
     use super::*;
@@ -13,6 +13,9 @@ mod test_module {
 
         #[state]
         pub test_state2: StateMap<String, String, C::Storage>,
+
+        #[state]
+        pub test_state3: StateValue<String, C::Storage>,
     }
 }
 
@@ -41,6 +44,18 @@ fn main() {
             "trybuild000::test_module",
             "TestStruct",
             "test_state2"
+        )
+        .into()
+    );
+
+    let prefix2 = test_struct.test_state3.prefix();
+    assert_eq!(
+        *prefix2,
+        sov_modules_api::Prefix::new(
+            // The tests compile inside trybuild.
+            "trybuild000::test_module",
+            "TestStruct",
+            "test_state3"
         )
         .into()
     );

--- a/sov-modules/sov-state/src/backend.rs
+++ b/sov-modules/sov-state/src/backend.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 pub(crate) struct Backend<K, V, S> {
     _phantom: (PhantomData<K>, PhantomData<V>),
     storage: S,
-    // Every instance of the `StateMap` contains a unique prefix.
+    // Every instance of the `Backend` contains a unique prefix.
     // The prefix is prepended to each key before insertion and retrieval from the storage.
     prefix: Prefix,
 }

--- a/sov-modules/sov-state/src/backend.rs
+++ b/sov-modules/sov-state/src/backend.rs
@@ -9,8 +9,8 @@ use std::marker::PhantomData;
 pub(crate) struct Backend<K, V, S> {
     _phantom: (PhantomData<K>, PhantomData<V>),
     storage: S,
-    // Every instance of the `Backend` contains a unique prefix.
-    // The prefix is prepended to each key before insertion and retrieval from the storage.
+    /// Every instance of the `Backend` contains a unique prefix.
+    /// The prefix is prepended to each key before insertion and retrieval from the storage.
     prefix: Prefix,
 }
 

--- a/sov-modules/sov-state/src/backend.rs
+++ b/sov-modules/sov-state/src/backend.rs
@@ -1,0 +1,45 @@
+use crate::{
+    storage::{StorageKey, StorageValue},
+    Prefix, Storage,
+};
+use sovereign_sdk::serial::{Decode, Encode};
+use std::marker::PhantomData;
+
+#[derive(Debug)]
+pub(crate) struct Backend<K, V, S> {
+    _phantom: (PhantomData<K>, PhantomData<V>),
+    storage: S,
+    // Every instance of the `StateMap` contains a unique prefix.
+    // The prefix is prepended to each key before insertion and retrieval from the storage.
+    prefix: Prefix,
+}
+
+impl<K: Encode, V: Encode + Decode, S: Storage> Backend<K, V, S> {
+    pub(crate) fn new(storage: S, prefix: Prefix) -> Self {
+        Self {
+            _phantom: (PhantomData, PhantomData),
+            storage,
+            prefix,
+        }
+    }
+
+    pub(crate) fn prefix(&self) -> &Prefix {
+        &self.prefix
+    }
+
+    pub(crate) fn set_value(&mut self, storage_key: StorageKey, value: V) {
+        let storage_value = StorageValue::new(value);
+        self.storage.set(storage_key, storage_value);
+    }
+
+    pub(crate) fn get_value(&self, storage_key: StorageKey) -> Option<V> {
+        let storage_value = self.storage.get(storage_key)?.value;
+
+        let mut storage_reader: &[u8] = &storage_value;
+        // It is ok to panic here. Deserialization problem means that something is terribly wrong.
+        Some(
+            V::decode(&mut storage_reader)
+                .unwrap_or_else(|e| panic!("Unable to deserialize storage value {e:?}")),
+        )
+    }
+}

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -1,24 +1,54 @@
+use std::{cell::RefCell, rc::Rc};
+
 use crate::storage::{Storage, StorageKey, StorageValue};
-use first_read_last_write_cache::cache::CacheLog;
+use first_read_last_write_cache::{
+    cache::{self, CacheLog},
+    CacheValue,
+};
 use jellyfish_merkle_generic::Version;
 
 // Storage backed by JMT.
+#[derive(Default, Clone)]
 pub struct JmtStorage {
     // Caches first read and last write for a particular key.
-    _cache: CacheLog,
+    cache: Rc<RefCell<CacheLog>>,
     _version: Version,
 }
 
 impl Storage for JmtStorage {
-    fn get(&self, _key: StorageKey) -> Option<StorageValue> {
-        todo!()
+    fn get(&self, key: StorageKey) -> Option<StorageValue> {
+        let cache_key = key.into();
+        let cache_value = self.cache.borrow().get_value(&cache_key);
+
+        match cache_value {
+            cache::ExistsInCache::Yes(cache_value_exists) => match cache_value_exists.value.clone()
+            {
+                Some(value) => {
+                    self.cache
+                        .borrow_mut()
+                        .add_read(cache_key, cache_value_exists)
+                        // It is ok to panic here, we must guarantee that the cache is consistent.
+                        .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
+
+                    Some(StorageValue { value })
+                }
+                None => None,
+            },
+            // TODO If value does not exist in the cache, then fetch it from the JMT
+            cache::ExistsInCache::No => todo!(),
+        }
     }
 
-    fn set(&mut self, _key: StorageKey, _value: StorageValue) {
-        todo!()
+    fn set(&mut self, key: StorageKey, value: StorageValue) {
+        let cache_key = key.into();
+        let cache_value = value.into();
+        self.cache.borrow_mut().add_write(cache_key, cache_value);
     }
 
-    fn delete(&mut self, _key: StorageKey) {
-        todo!()
+    fn delete(&mut self, key: StorageKey) {
+        let cache_key = key.into();
+        self.cache
+            .borrow_mut()
+            .add_write(cache_key, CacheValue::empty());
     }
 }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -34,7 +34,7 @@ impl Storage for JmtStorage {
                 }
                 None => None,
             },
-            // TODO If value does not exist in the cache, then fetch it from the JMT
+            // TODO If the value does not exist in the cache, then fetch it from the JMT.
             cache::ExistsInCache::No => todo!(),
         }
     }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -21,19 +21,15 @@ impl Storage for JmtStorage {
         let cache_value = self.cache.borrow().get_value(&cache_key);
 
         match cache_value {
-            cache::ExistsInCache::Yes(cache_value_exists) => match cache_value_exists.value.clone()
-            {
-                Some(value) => {
-                    self.cache
-                        .borrow_mut()
-                        .add_read(cache_key, cache_value_exists)
-                        // It is ok to panic here, we must guarantee that the cache is consistent.
-                        .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
+            cache::ExistsInCache::Yes(cache_value_exists) => {
+                self.cache
+                    .borrow_mut()
+                    .add_read(cache_key, cache_value_exists.clone())
+                    // It is ok to panic here, we must guarantee that the cache is consistent.
+                    .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
 
-                    Some(StorageValue { value })
-                }
-                None => None,
-            },
+                cache_value_exists.value.map(|value| StorageValue { value })
+            }
             // TODO If the value does not exist in the cache, then fetch it from the JMT.
             cache::ExistsInCache::No => todo!(),
         }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -17,7 +17,7 @@ pub struct JmtStorage {
 
 impl Storage for JmtStorage {
     fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        let cache_key = key.into();
+        let cache_key = key.as_cache_key();
         let cache_value = self.cache.borrow().get_value(&cache_key);
 
         match cache_value {
@@ -36,13 +36,13 @@ impl Storage for JmtStorage {
     }
 
     fn set(&mut self, key: StorageKey, value: StorageValue) {
-        let cache_key = key.into();
-        let cache_value = value.into();
+        let cache_key = key.as_cache_key();
+        let cache_value = value.as_cache_value();
         self.cache.borrow_mut().add_write(cache_key, cache_value);
     }
 
     fn delete(&mut self, key: StorageKey) {
-        let cache_key = key.into();
+        let cache_key = key.as_cache_key();
         self.cache
             .borrow_mut()
             .add_write(cache_key, CacheValue::empty());

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -11,9 +11,6 @@ use utils::AlignedVec;
 
 pub use value::StateValue;
 
-#[cfg(test)]
-pub use value::SingletonKey;
-
 // A prefix prepended to each key before insertion and retrieval from the storage.
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
 // to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -8,6 +8,7 @@ pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;
 use utils::AlignedVec;
+pub use value::SingletonKey;
 pub use value::StateValue;
 
 // A prefix prepended to each key before insertion and retrieval from the storage.

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -1,15 +1,18 @@
+mod backend;
 mod jmt_storage;
 mod map;
 pub mod storage;
 mod utils;
 mod value;
-
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;
 use utils::AlignedVec;
-pub use value::SingletonKey;
+
 pub use value::StateValue;
+
+#[cfg(test)]
+pub use value::SingletonKey;
 
 // A prefix prepended to each key before insertion and retrieval from the storage.
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -2,11 +2,13 @@ mod jmt_storage;
 mod map;
 pub mod storage;
 mod utils;
+mod value;
 
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;
 use utils::AlignedVec;
+pub use value::StateValue;
 
 // A prefix prepended to each key before insertion and retrieval from the storage.
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -1,58 +1,32 @@
-use crate::{
-    storage::{StorageKey, StorageValue},
-    Prefix, Storage,
-};
+use crate::{backend::Backend, storage::StorageKey, Prefix, Storage};
 use sovereign_sdk::serial::{Decode, Encode};
-use std::marker::PhantomData;
 
 /// A container that maps keys to values.
 #[derive(Debug)]
 pub struct StateMap<K, V, S> {
-    _phantom: (PhantomData<K>, PhantomData<V>),
-    storage: S,
-    // Every instance of the `StateMap` contains a unique prefix.
-    // The prefix is prepended to each key before insertion and retrieval from the storage.
-    prefix: Prefix,
+    backend: Backend<K, V, S>,
 }
 
 impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     pub fn new(storage: S, prefix: Prefix) -> Self {
         Self {
-            _phantom: (PhantomData, PhantomData),
-            storage,
-            prefix,
+            backend: Backend::new(storage, prefix),
         }
     }
 
     /// Inserts a key-value pair into the map.
     pub fn set(&mut self, key: K, value: V) {
-        let storage_key = StorageKey::new(&self.prefix, key);
-        self.set_value(storage_key, value)
+        let storage_key = StorageKey::new(self.backend.prefix(), key);
+        self.backend.set_value(storage_key, value)
     }
 
     /// Returns the value corresponding to the key or None if key is absent in the StateMap.
     pub fn get(&self, key: K) -> Option<V> {
-        let storage_key = StorageKey::new(&self.prefix, key);
-        self.get_value(storage_key)
+        let storage_key = StorageKey::new(self.backend.prefix(), key);
+        self.backend.get_value(storage_key)
     }
 
     pub fn prefix(&self) -> &Prefix {
-        &self.prefix
-    }
-
-    pub(crate) fn set_value(&mut self, storage_key: StorageKey, value: V) {
-        let storage_value = StorageValue::new(value);
-        self.storage.set(storage_key, storage_value);
-    }
-
-    pub(crate) fn get_value(&self, storage_key: StorageKey) -> Option<V> {
-        let storage_value = self.storage.get(storage_key)?.value;
-
-        let mut storage_reader: &[u8] = &storage_value;
-        // It is ok to panic here. Deserialization problem means that something is terribly wrong.
-        Some(
-            V::decode(&mut storage_reader)
-                .unwrap_or_else(|e| panic!("Unable to deserialize storage value {e:?}")),
-        )
+        self.backend.prefix()
     }
 }

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -27,13 +27,25 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     // Inserts a key-value pair into the map.
     pub fn set(&mut self, key: K, value: V) {
         let storage_key = StorageKey::new(&self.prefix, key);
-        let storage_value = StorageValue::new(value);
-        self.storage.set(storage_key, storage_value);
+        self.set_value(storage_key, value)
     }
 
     // Returns the value corresponding to the key or None if key is absent in the StateMap.
     pub fn get(&self, key: K) -> Option<V> {
         let storage_key = StorageKey::new(&self.prefix, key);
+        self.get_value(storage_key)
+    }
+
+    pub fn prefix(&self) -> &Prefix {
+        &self.prefix
+    }
+
+    pub(crate) fn set_value(&mut self, storage_key: StorageKey, value: V) {
+        let storage_value = StorageValue::new(value);
+        self.storage.set(storage_key, storage_value);
+    }
+
+    pub(crate) fn get_value(&self, storage_key: StorageKey) -> Option<V> {
         let storage_value = self.storage.get(storage_key)?.value;
 
         let mut storage_reader: &[u8] = &storage_value;
@@ -42,9 +54,5 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
             V::decode(&mut storage_reader)
                 .unwrap_or_else(|e| panic!("Unable to deserialize storage value {e:?}")),
         )
-    }
-
-    pub fn prefix(&self) -> &Prefix {
-        &self.prefix
     }
 }

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -5,7 +5,7 @@ use crate::{
 use sovereign_sdk::serial::{Decode, Encode};
 use std::marker::PhantomData;
 
-// A container that maps keys to values.
+/// A container that maps keys to values.
 #[derive(Debug)]
 pub struct StateMap<K, V, S> {
     _phantom: (PhantomData<K>, PhantomData<V>),
@@ -24,13 +24,13 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
         }
     }
 
-    // Inserts a key-value pair into the map.
+    /// Inserts a key-value pair into the map.
     pub fn set(&mut self, key: K, value: V) {
         let storage_key = StorageKey::new(&self.prefix, key);
         self.set_value(storage_key, value)
     }
 
-    // Returns the value corresponding to the key or None if key is absent in the StateMap.
+    /// Returns the value corresponding to the key or None if key is absent in the StateMap.
     pub fn get(&self, key: K) -> Option<V> {
         let storage_key = StorageKey::new(&self.prefix, key);
         self.get_value(storage_key)

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -15,17 +15,15 @@ impl StorageKey {
     pub fn key(&self) -> Arc<Vec<u8>> {
         self.key.clone()
     }
+
+    pub fn as_cache_key(self) -> CacheKey {
+        CacheKey { key: self.key }
+    }
 }
 
 impl AsRef<Vec<u8>> for StorageKey {
     fn as_ref(&self) -> &Vec<u8> {
         &self.key
-    }
-}
-
-impl From<StorageKey> for CacheKey {
-    fn from(key: StorageKey) -> Self {
-        Self { key: key.key }
     }
 }
 
@@ -54,19 +52,18 @@ pub struct StorageValue {
     pub value: Arc<Vec<u8>>,
 }
 
-impl From<StorageValue> for CacheValue {
-    fn from(value: StorageValue) -> Self {
-        Self {
-            value: Some(value.value),
-        }
-    }
-}
 impl StorageValue {
     pub fn new<V: Encode>(value: V) -> Self {
         let mut encoded_value = Vec::default();
         value.encode(&mut encoded_value);
         Self {
             value: Arc::new(encoded_value),
+        }
+    }
+
+    pub fn as_cache_value(self) -> CacheValue {
+        CacheValue {
+            value: Some(self.value),
         }
     }
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use first_read_last_write_cache::{CacheKey, CacheValue};
 use sovereign_sdk::serial::Encode;
 
 use crate::{utils::AlignedVec, Prefix};
@@ -19,6 +20,12 @@ impl StorageKey {
 impl AsRef<Vec<u8>> for StorageKey {
     fn as_ref(&self) -> &Vec<u8> {
         &self.key
+    }
+}
+
+impl From<StorageKey> for CacheKey {
+    fn from(key: StorageKey) -> Self {
+        Self { key: key.key }
     }
 }
 
@@ -47,6 +54,13 @@ pub struct StorageValue {
     pub value: Arc<Vec<u8>>,
 }
 
+impl From<StorageValue> for CacheValue {
+    fn from(value: StorageValue) -> Self {
+        Self {
+            value: Some(value.value),
+        }
+    }
+}
 impl StorageValue {
     pub fn new<V: Encode>(value: V) -> Self {
         let mut encoded_value = Vec::default();

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -30,7 +30,7 @@ impl From<StorageKey> for CacheKey {
 }
 
 impl StorageKey {
-    // Creates a new prefixed StorageKey.
+    /// Creates a new StorageKey that combines prefix and key.
     pub fn new<K: Encode>(prefix: &Prefix, key: K) -> Self {
         let mut encoded_key = Vec::default();
         key.encode(&mut encoded_key);
@@ -44,12 +44,6 @@ impl StorageKey {
 
         Self {
             key: Arc::new(full_key.into_inner()),
-        }
-    }
-
-    pub fn new_with_empty_state_key(prefix: &Prefix) -> Self {
-        Self {
-            key: Arc::new(prefix.as_aligned_vec().clone().into_inner()),
         }
     }
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -46,6 +46,12 @@ impl StorageKey {
             key: Arc::new(full_key.into_inner()),
         }
     }
+
+    pub fn new_with_empty_state_key(prefix: &Prefix) -> Self {
+        Self {
+            key: Arc::new(prefix.as_aligned_vec().clone().into_inner()),
+        }
+    }
 }
 
 // `Value` type for the `Storage`

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -30,7 +30,7 @@ impl From<StorageKey> for CacheKey {
 }
 
 impl StorageKey {
-    /// Creates a new StorageKey that combines prefix and key.
+    /// Creates a new StorageKey that combines a prefix and a key.
     pub fn new<K: Encode>(prefix: &Prefix, key: K) -> Self {
         let mut encoded_key = Vec::default();
         key.encode(&mut encoded_key);

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -2,7 +2,7 @@
 // This makes certain operations cheaper in zk-context (concatenation)
 // TODO: Currently the implementation defaults to `stc::vec::Vec` see:
 // https://github.com/Sovereign-Labs/sovereign/issues/47
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AlignedVec {
     inner: Vec<u8>,
 }

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -2,7 +2,7 @@
 // This makes certain operations cheaper in zk-context (concatenation)
 // TODO: Currently the implementation defaults to `stc::vec::Vec` see:
 // https://github.com/Sovereign-Labs/sovereign/issues/47
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AlignedVec {
     inner: Vec<u8>,
 }

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -1,10 +1,10 @@
-use crate::{storage::StorageKey, Prefix, StateMap, Storage};
+use crate::{backend::Backend, storage::StorageKey, Prefix, Storage};
 use sovereign_sdk::serial::{Decode, Encode};
-use std::marker::PhantomData;
 
-/// SingletonKey is very similar to the unit type `()` i.e. it has only one value.
-/// We provide a custom efficient Encode implementation for SingletonKey while Encode for `()`
-/// is likely already implemented by an external library (like borsh), which is outside of our control.
+// SingletonKey is very similar to the unit type `()` i.e. it has only one value.
+// We provide a custom efficient Encode implementation for SingletonKey while Encode for `()`
+// is likely already implemented by an external library (like borsh), which is outside of our control.
+
 #[derive(Debug)]
 pub struct SingletonKey;
 
@@ -17,16 +17,14 @@ impl Encode for SingletonKey {
 /// Container for a single value.
 #[derive(Debug)]
 pub struct StateValue<V, S> {
-    _phantom: PhantomData<V>,
-    // StateValue is equivalent to a StateMap with a single key.
-    map: StateMap<SingletonKey, V, S>,
+    // StateValue is equivalent to a Backend with a single key.
+    backend: Backend<SingletonKey, V, S>,
 }
 
 impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
     pub fn new(storage: S, prefix: Prefix) -> Self {
         Self {
-            _phantom: PhantomData,
-            map: StateMap::new(storage, prefix),
+            backend: Backend::new(storage, prefix),
         }
     }
 
@@ -34,17 +32,17 @@ impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
     pub fn set(&mut self, value: V) {
         // `StorageKey::new` will serialize the SingletonKey, but that's fine because we provided
         //  efficient Encode implementation.
-        let storage_key = StorageKey::new(self.map.prefix(), SingletonKey);
-        self.map.set_value(storage_key, value)
+        let storage_key = StorageKey::new(self.backend.prefix(), SingletonKey);
+        self.backend.set_value(storage_key, value)
     }
 
     /// Gets a value from the StateValue.
     pub fn get(&self) -> Option<V> {
-        let storage_key = StorageKey::new(self.map.prefix(), SingletonKey);
-        self.map.get_value(storage_key)
+        let storage_key = StorageKey::new(self.backend.prefix(), SingletonKey);
+        self.backend.get_value(storage_key)
     }
 
     pub fn prefix(&self) -> &Prefix {
-        self.map.prefix()
+        self.backend.prefix()
     }
 }

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 /// SingletonKey is very similar to the unit type `()` i.e. it has only one value.
 /// We provide a custom efficient Encode implementation for SingletonKey while Encode for `()`
-/// is likely implemented by an external library which is outside of our control.
+/// is likely already implemented by an external library (like borsh) which is outside of our control.
 #[derive(Debug)]
 pub struct SingletonKey;
 
@@ -18,6 +18,7 @@ impl Encode for SingletonKey {
 #[derive(Debug)]
 pub struct StateValue<V, S> {
     _phantom: PhantomData<V>,
+    // StateValue is equivalent to a StateMap with a single key.
     map: StateMap<SingletonKey, V, S>,
 }
 

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -1,0 +1,33 @@
+use crate::{storage::StorageKey, Prefix, StateMap, Storage};
+use sovereign_sdk::serial::{Decode, Encode};
+use std::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct StateValue<V, S> {
+    _phantom: PhantomData<V>,
+    // TODO comment
+    map: StateMap<(), V, S>,
+}
+
+impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
+    pub fn new(storage: S, prefix: Prefix) -> Self {
+        Self {
+            _phantom: PhantomData,
+            map: StateMap::new(storage, prefix),
+        }
+    }
+
+    pub fn set(&mut self, value: V) {
+        let storage_key = StorageKey::new_with_empty_state_key(self.map.prefix());
+        self.map.set_value(storage_key, value)
+    }
+
+    pub fn get(&self) -> Option<V> {
+        let storage_key = StorageKey::new_with_empty_state_key(self.map.prefix());
+        self.map.get_value(storage_key)
+    }
+
+    pub fn prefix(&self) -> &Prefix {
+        self.map.prefix()
+    }
+}

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 /// SingletonKey is very similar to the unit type `()` i.e. it has only one value.
 /// We provide a custom efficient Encode implementation for SingletonKey while Encode for `()`
-/// is likely already implemented by an external library (like borsh) which is outside of our control.
+/// is likely already implemented by an external library (like borsh), which is outside of our control.
 #[derive(Debug)]
 pub struct SingletonKey;
 


### PR DESCRIPTION
This PR introduces the following changes:
1. `StateValue` struct: a container for a single value.
2. Updates tests to use the new `StateValue`.
3. Removes `MockStorage`. We can use `JMT` for tests as we can store data inside the cache for now. 

close #34