### PR TITLE
`ZkStorage` implementation

### DIFF
--- a/first-read-last-write-cache/src/cache.rs
+++ b/first-read-last-write-cache/src/cache.rs
@@ -31,12 +31,17 @@ pub struct CacheLog {
     log: HashMap<CacheKey, Access>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct FirstReads {
     reads: Arc<HashMap<CacheKey, CacheValue>>,
 }
 
 impl FirstReads {
+    pub fn new(reads: HashMap<CacheKey, CacheValue>) -> Self {
+        Self {
+            reads: Arc::new(reads),
+        }
+    }
     pub fn read(&self, key: &CacheKey) -> ExistsInCache {
         match self.reads.get(key) {
             Some(read) => ExistsInCache::Yes(read.clone()),
@@ -61,9 +66,7 @@ impl CacheLog {
             .filter_map(|(k, v)| filter_first_reads(k.clone(), v.clone()))
             .collect::<HashMap<_, _>>();
 
-        FirstReads {
-            reads: Arc::new(reads),
-        }
+        FirstReads::new(reads)
     }
 
     /// Gets value form the cache.

--- a/first-read-last-write-cache/src/cache.rs
+++ b/first-read-last-write-cache/src/cache.rs
@@ -404,4 +404,27 @@ mod tests {
             assert!(result.is_err());
         }
     }
+
+    #[test]
+    fn test_first_reads() {
+        let mut cache = CacheLog::default();
+        let entries = vec![
+            new_cache_entry(1, 11),
+            new_cache_entry(2, 22),
+            new_cache_entry(3, 33),
+        ];
+
+        for entry in entries.clone() {
+            cache.add_read(entry.key, entry.value).unwrap();
+        }
+
+        let first_reads = cache.get_first_reads();
+
+        for entry in entries {
+            match first_reads.get(&entry.key) {
+                ValueExists::Yes(value) => assert_eq!(entry.value, value),
+                ValueExists::No => unreachable!(),
+            }
+        }
+    }
 }

--- a/first-read-last-write-cache/src/cache.rs
+++ b/first-read-last-write-cache/src/cache.rs
@@ -73,7 +73,7 @@ impl CacheLog {
         FirstReads::new(reads)
     }
 
-    // Returns a value corresponding to the key.
+    /// Returns a value corresponding to the key.
     pub fn get_value(&self, key: &CacheKey) -> ValueExists {
         match self.log.get(key) {
             Some(value) => ValueExists::Yes(value.last_value().clone()),

--- a/first-read-last-write-cache/src/cache.rs
+++ b/first-read-last-write-cache/src/cache.rs
@@ -31,7 +31,7 @@ pub struct CacheLog {
     log: HashMap<CacheKey, Access>,
 }
 
-/// Represents all reads form a CacheLog.
+/// Represents all reads from a CacheLog.
 #[derive(Default, Clone, Debug)]
 pub struct FirstReads {
     reads: Arc<HashMap<CacheKey, CacheValue>>,

--- a/first-read-last-write-cache/src/cache.rs
+++ b/first-read-last-write-cache/src/cache.rs
@@ -15,12 +15,12 @@ pub enum ReadError {
 
 /// Cache entry can be in three states:
 /// - Does not exists, a given key was never inserted in the cache:             
-///     ExistsInCache::No
+///     ValueExists::No
 /// - Exists but the value is empty.
-///      ExistsInCache::Yes(None)
+///      ValueExists::Yes(None)
 /// - Exists and contains a value:
-///     ExistsInCache::Yes(Some(value))
-pub enum ExistsInCache {
+///     ValueExists::Yes(Some(value))
+pub enum ValueExists {
     Yes(CacheValue),
     No,
 }
@@ -31,6 +31,7 @@ pub struct CacheLog {
     log: HashMap<CacheKey, Access>,
 }
 
+/// Represents all reads form a CacheLog.
 #[derive(Default, Clone, Debug)]
 pub struct FirstReads {
     reads: Arc<HashMap<CacheKey, CacheValue>>,
@@ -42,10 +43,12 @@ impl FirstReads {
             reads: Arc::new(reads),
         }
     }
-    pub fn read(&self, key: &CacheKey) -> ExistsInCache {
+
+    /// Returns a value corresponding to the key.
+    pub fn get(&self, key: &CacheKey) -> ValueExists {
         match self.reads.get(key) {
-            Some(read) => ExistsInCache::Yes(read.clone()),
-            None => ExistsInCache::No,
+            Some(read) => ValueExists::Yes(read.clone()),
+            None => ValueExists::No,
         }
     }
 }
@@ -59,6 +62,7 @@ impl CacheLog {
 }
 
 impl CacheLog {
+    /// Returns all reads from the CacheLog.
     pub fn get_first_reads(&self) -> FirstReads {
         let reads = self
             .log
@@ -69,11 +73,11 @@ impl CacheLog {
         FirstReads::new(reads)
     }
 
-    /// Gets value form the cache.
-    pub fn get_value(&self, key: &CacheKey) -> ExistsInCache {
+    // Returns a value corresponding to the key.
+    pub fn get_value(&self, key: &CacheKey) -> ValueExists {
         match self.log.get(key) {
-            Some(value) => ExistsInCache::Yes(value.last_value().clone()),
-            None => ExistsInCache::No,
+            Some(value) => ValueExists::Yes(value.last_value().clone()),
+            None => ValueExists::No,
         }
     }
 
@@ -160,11 +164,11 @@ mod tests {
     use super::*;
     use crate::utils::test_util::{create_key, create_value};
 
-    impl ExistsInCache {
+    impl ValueExists {
         fn get(self) -> CacheValue {
             match self {
-                ExistsInCache::Yes(value) => value,
-                ExistsInCache::No => unreachable!(),
+                ValueExists::Yes(value) => value,
+                ValueExists::No => unreachable!(),
             }
         }
     }

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -1,5 +1,5 @@
 use crate::Context;
-use sov_state::JmtStorage;
+use sov_state::{JmtStorage, ZkStorage};
 
 /// Mock for Context::PublicKey, useful for testing.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, PartialEq, Eq)]
@@ -32,6 +32,22 @@ pub struct MockContext {
 
 impl Context for MockContext {
     type Storage = JmtStorage;
+
+    type Signature = MockSignature;
+
+    type PublicKey = MockPublicKey;
+
+    fn sender(&self) -> &Self::PublicKey {
+        &self.sender
+    }
+}
+
+pub struct ZkMockContext {
+    sender: MockPublicKey,
+}
+
+impl Context for ZkMockContext {
+    type Storage = ZkStorage;
 
     type Signature = MockSignature;
 

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -76,7 +76,7 @@ fn nested_module_call_test() {
 
     // Test the `zk` execution.
     {
-        let zk_storage = ZkStorage::new(native_storage.reads());
+        let zk_storage = ZkStorage::new(native_storage.get_first_reads());
         execute_module_logic::<ZkMockContext>(zk_storage.clone());
         test_state_update::<ZkMockContext>(zk_storage);
     }

--- a/sov-modules/sov-modules-impl/tests/tests.rs
+++ b/sov-modules/sov-modules-impl/tests/tests.rs
@@ -67,11 +67,14 @@ mod module_c {
 #[test]
 fn nested_module_call_test() {
     let native_storage = JmtStorage::default();
+
+    // Test the `native` execution.
     {
         execute_module_logic::<MockContext>(native_storage.clone());
         test_state_update::<MockContext>(native_storage.clone());
     }
 
+    // Test the `zk` execution.
     {
         let zk_storage = ZkStorage::new(native_storage.reads());
         execute_module_logic::<ZkMockContext>(zk_storage.clone());

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -5,8 +5,8 @@ use first_read_last_write_cache::{
 };
 use std::{cell::RefCell, rc::Rc};
 
-pub(crate) trait GetValue {
-    fn get_value(&self, key: StorageKey) -> Option<StorageValue>;
+pub(crate) trait ValueReader {
+    fn read_value(&self, key: StorageKey) -> Option<StorageValue>;
 }
 
 #[derive(Default, Clone)]
@@ -15,10 +15,10 @@ pub(crate) struct Cache {
 }
 
 impl Cache {
-    pub(crate) fn get<G: GetValue>(
+    pub(crate) fn get<VR: ValueReader>(
         &self,
         key: StorageKey,
-        value_getter: &G,
+        value_getter: &VR,
     ) -> Option<StorageValue> {
         let cache_key = key.clone().as_cache_key();
         let cache_value = self.cache.borrow().get_value(&cache_key);
@@ -34,7 +34,7 @@ impl Cache {
                 cache_value_exists.value.map(|value| StorageValue { value })
             }
             // TODO If the value does not exist in the cache, then fetch it from the JMT.
-            cache::ExistsInCache::No => value_getter.get_value(key),
+            cache::ExistsInCache::No => value_getter.read_value(key),
         }
     }
 

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -5,10 +5,12 @@ use first_read_last_write_cache::{
 };
 use std::{cell::RefCell, rc::Rc};
 
+///
 pub(crate) trait ValueReader {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue>;
 }
 
+///
 #[derive(Default, Clone)]
 pub(crate) struct Cache {
     pub(crate) cache: Rc<RefCell<CacheLog>>,
@@ -33,7 +35,7 @@ impl Cache {
 
                 cache_value_exists.value.map(|value| StorageValue { value })
             }
-            // TODO If the value does not exist in the cache, then fetch it from the JMT.
+            // TODO If the value does not exist in the cache, then fetch it from the external source.
             cache::ExistsInCache::No => value_getter.read_value(key),
         }
     }

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -1,0 +1,53 @@
+use crate::storage::{StorageKey, StorageValue};
+use first_read_last_write_cache::{
+    cache::{self, CacheLog},
+    CacheValue,
+};
+use std::{cell::RefCell, rc::Rc};
+
+pub(crate) trait GetValue {
+    fn get_value(&self, key: StorageKey) -> Option<StorageValue>;
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct Cache {
+    cache: Rc<RefCell<CacheLog>>,
+}
+
+impl Cache {
+    pub(crate) fn get<G: GetValue>(
+        &self,
+        key: StorageKey,
+        value_getter: &G,
+    ) -> Option<StorageValue> {
+        let cache_key = key.clone().as_cache_key();
+        let cache_value = self.cache.borrow().get_value(&cache_key);
+
+        match cache_value {
+            cache::ExistsInCache::Yes(cache_value_exists) => {
+                self.cache
+                    .borrow_mut()
+                    .add_read(cache_key, cache_value_exists.clone())
+                    // It is ok to panic here, we must guarantee that the cache is consistent.
+                    .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
+
+                cache_value_exists.value.map(|value| StorageValue { value })
+            }
+            // TODO If the value does not exist in the cache, then fetch it from the JMT.
+            cache::ExistsInCache::No => value_getter.get_value(key),
+        }
+    }
+
+    pub(crate) fn set(&mut self, key: StorageKey, value: StorageValue) {
+        let cache_key = key.as_cache_key();
+        let cache_value = value.as_cache_value();
+        self.cache.borrow_mut().add_write(cache_key, cache_value);
+    }
+
+    pub(crate) fn delete(&mut self, key: StorageKey) {
+        let cache_key = key.as_cache_key();
+        self.cache
+            .borrow_mut()
+            .add_write(cache_key, CacheValue::empty());
+    }
+}

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -11,7 +11,7 @@ pub(crate) trait ValueReader {
 
 #[derive(Default, Clone)]
 pub(crate) struct Cache {
-    cache: Rc<RefCell<CacheLog>>,
+    pub(crate) cache: Rc<RefCell<CacheLog>>,
 }
 
 impl Cache {

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -6,7 +6,7 @@ use first_read_last_write_cache::{
 use std::{cell::RefCell, rc::Rc};
 
 /// `ValueReader` Reads a value from an external data source.
-pub(crate) trait ValueReader {
+pub trait ValueReader {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue>;
 }
 

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -38,7 +38,7 @@ impl StorageInternalCache {
 
                 cache_value_exists.value.map(|value| StorageValue { value })
             }
-            // TODO If the value does not exist in the cache, then fetch it from an external source.
+            // If the value does not exist in the cache, then fetch it from an external source.
             cache::ValueExists::No => value_reader.read_value(key),
         }
     }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -6,24 +6,35 @@ use first_read_last_write_cache::cache::{CacheLog, FirstReads};
 use jellyfish_merkle_generic::Version;
 
 #[derive(Default, Clone)]
-struct JMT {}
+pub struct Jmt {}
 
-impl ValueReader for JMT {
-    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
+///
+impl ValueReader for Jmt {
+    fn read_value(&self, _key: StorageKey) -> Option<StorageValue> {
         todo!()
     }
 }
 
-// Storage backed by JMT.
+// Storage backed by Jmt.
 #[derive(Default, Clone)]
 pub struct JmtStorage {
     // Caches first read and last write for a particular key.
     cache: Cache,
-    jmt: JMT,
+    jmt: Jmt,
     _version: Version,
 }
 
 impl JmtStorage {
+    ///
+    pub fn new(jmt: Jmt, _version: Version) -> Self {
+        Self {
+            cache: Cache::default(),
+            jmt,
+            _version,
+        }
+    }
+
+    ///
     pub fn reads(&self) -> FirstReads {
         let cache: &CacheLog = &self.cache.cache.borrow();
         cache.get_first_reads()

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -1,5 +1,5 @@
 use crate::{
-    internal_cache::{Cache, GetValue},
+    internal_cache::{Cache, ValueReader},
     storage::{Storage, StorageKey, StorageValue},
 };
 use jellyfish_merkle_generic::Version;
@@ -7,8 +7,8 @@ use jellyfish_merkle_generic::Version;
 #[derive(Default, Clone)]
 struct JMT {}
 
-impl GetValue for JMT {
-    fn get_value(&self, key: StorageKey) -> Option<StorageValue> {
+impl ValueReader for JMT {
+    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
         todo!()
     }
 }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -2,6 +2,7 @@ use crate::{
     internal_cache::{Cache, ValueReader},
     storage::{Storage, StorageKey, StorageValue},
 };
+use first_read_last_write_cache::cache::{CacheLog, FirstReads};
 use jellyfish_merkle_generic::Version;
 
 #[derive(Default, Clone)]
@@ -20,6 +21,13 @@ pub struct JmtStorage {
     cache: Cache,
     jmt: JMT,
     _version: Version,
+}
+
+impl JmtStorage {
+    pub fn reads(&self) -> FirstReads {
+        let cache: &CacheLog = &self.cache.cache.borrow();
+        cache.get_first_reads()
+    }
 }
 
 impl Storage for JmtStorage {

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -1,50 +1,37 @@
-use std::{cell::RefCell, rc::Rc};
-
-use crate::storage::{Storage, StorageKey, StorageValue};
-use first_read_last_write_cache::{
-    cache::{self, CacheLog},
-    CacheValue,
+use crate::{
+    internal_cache::{Cache, GetValue},
+    storage::{Storage, StorageKey, StorageValue},
 };
 use jellyfish_merkle_generic::Version;
+
+#[derive(Default, Clone)]
+struct JMT {}
+
+impl GetValue for JMT {
+    fn get_value(&self, key: StorageKey) -> Option<StorageValue> {
+        todo!()
+    }
+}
 
 // Storage backed by JMT.
 #[derive(Default, Clone)]
 pub struct JmtStorage {
     // Caches first read and last write for a particular key.
-    cache: Rc<RefCell<CacheLog>>,
+    cache: Cache,
+    jmt: JMT,
     _version: Version,
 }
 
 impl Storage for JmtStorage {
     fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        let cache_key = key.as_cache_key();
-        let cache_value = self.cache.borrow().get_value(&cache_key);
-
-        match cache_value {
-            cache::ExistsInCache::Yes(cache_value_exists) => {
-                self.cache
-                    .borrow_mut()
-                    .add_read(cache_key, cache_value_exists.clone())
-                    // It is ok to panic here, we must guarantee that the cache is consistent.
-                    .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
-
-                cache_value_exists.value.map(|value| StorageValue { value })
-            }
-            // TODO If the value does not exist in the cache, then fetch it from the JMT.
-            cache::ExistsInCache::No => todo!(),
-        }
+        self.cache.get(key, &self.jmt)
     }
 
     fn set(&mut self, key: StorageKey, value: StorageValue) {
-        let cache_key = key.as_cache_key();
-        let cache_value = value.as_cache_value();
-        self.cache.borrow_mut().add_write(cache_key, cache_value);
+        self.cache.set(key, value)
     }
 
     fn delete(&mut self, key: StorageKey) {
-        let cache_key = key.as_cache_key();
-        self.cache
-            .borrow_mut()
-            .add_write(cache_key, CacheValue::empty());
+        self.cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -1,6 +1,6 @@
 use crate::{
     internal_cache::{StorageInternalCache, ValueReader},
-    storage::{Storage, StorageKey, StorageValue},
+    storage::{GenericStorage, StorageKey, StorageValue},
 };
 use first_read_last_write_cache::cache::{CacheLog, FirstReads};
 use jellyfish_merkle_generic::Version;
@@ -17,19 +17,14 @@ impl ValueReader for JmtDb {
 }
 
 /// Storage backed by JmtDb.
-#[derive(Default, Clone)]
-pub struct JmtStorage {
-    // Caches first read and last write for a particular key.
-    internal_cache: StorageInternalCache,
-    jmt: JmtDb,
-}
+pub type JmtStorage = GenericStorage<JmtDb>;
 
 impl JmtStorage {
     /// Creates a new JmtStorage.
     pub fn new(jmt: JmtDb) -> Self {
         Self {
             internal_cache: StorageInternalCache::default(),
-            jmt,
+            value_reader: jmt,
         }
     }
 
@@ -37,19 +32,5 @@ impl JmtStorage {
     pub fn get_first_reads(&self) -> FirstReads {
         let cache: &CacheLog = &self.internal_cache.cache.borrow();
         cache.get_first_reads()
-    }
-}
-
-impl Storage for JmtStorage {
-    fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.internal_cache.get_or_fetch(key, &self.jmt)
-    }
-
-    fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.internal_cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: StorageKey) {
-        self.internal_cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -6,7 +6,9 @@ use first_read_last_write_cache::cache::{CacheLog, FirstReads};
 use jellyfish_merkle_generic::Version;
 
 #[derive(Default, Clone)]
-pub struct JmtDb {}
+pub struct JmtDb {
+    _version: Version,
+}
 
 impl ValueReader for JmtDb {
     fn read_value(&self, _key: StorageKey) -> Option<StorageValue> {
@@ -20,21 +22,19 @@ pub struct JmtStorage {
     // Caches first read and last write for a particular key.
     internal_cache: StorageInternalCache,
     jmt: JmtDb,
-    _version: Version,
 }
 
 impl JmtStorage {
-    ///
-    pub fn new(jmt: JmtDb, _version: Version) -> Self {
+    /// Creates a new JmtStorage.
+    pub fn new(jmt: JmtDb) -> Self {
         Self {
             internal_cache: StorageInternalCache::default(),
             jmt,
-            _version,
         }
     }
 
-    ///
-    pub fn reads(&self) -> FirstReads {
+    /// Gets the first reads from the JmtStorage.
+    pub fn get_first_reads(&self) -> FirstReads {
         let cache: &CacheLog = &self.internal_cache.cache.borrow();
         cache.get_first_reads()
     }

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -7,6 +7,9 @@ mod utils;
 mod value;
 mod zk_storage;
 
+#[cfg(test)]
+mod storage_test;
+
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -11,6 +11,7 @@ pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;
 use utils::AlignedVec;
+pub use zk_storage::ZkStorage;
 
 pub use value::StateValue;
 

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -1,9 +1,12 @@
 mod backend;
+mod internal_cache;
 mod jmt_storage;
 mod map;
 pub mod storage;
 mod utils;
 mod value;
+mod zk_storage;
+
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
 pub use storage::Storage;

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -79,3 +79,22 @@ pub trait Storage {
     // Deletes a key from the storage.
     fn delete(&mut self, key: StorageKey);
 }
+
+// ==== Used only for tests ====
+#[cfg(test)]
+impl From<&'static str> for StorageKey {
+    fn from(key: &'static str) -> Self {
+        Self {
+            key: Arc::new(key.as_bytes().to_vec()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<&'static str> for StorageValue {
+    fn from(value: &'static str) -> Self {
+        Self {
+            value: Arc::new(value.as_bytes().to_vec()),
+        }
+    }
+}

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -80,7 +80,7 @@ pub trait Storage {
     fn delete(&mut self, key: StorageKey);
 }
 
-// ==== Used only for tests ====
+// Used only in tests.
 #[cfg(test)]
 impl From<&'static str> for StorageKey {
     fn from(key: &'static str) -> Self {
@@ -90,6 +90,7 @@ impl From<&'static str> for StorageKey {
     }
 }
 
+// Used only in tests.
 #[cfg(test)]
 impl From<&'static str> for StorageValue {
     fn from(value: &'static str) -> Self {

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use first_read_last_write_cache::{CacheKey, CacheValue};
 use sovereign_sdk::serial::Encode;
 
-use crate::{utils::AlignedVec, Prefix};
+use crate::{
+    internal_cache::{StorageInternalCache, ValueReader},
+    utils::AlignedVec,
+    Prefix,
+};
 
 // `Key` type for the `Storage`
 #[derive(Clone, PartialEq, Eq)]
@@ -78,6 +82,27 @@ pub trait Storage {
 
     // Deletes a key from the storage.
     fn delete(&mut self, key: StorageKey);
+}
+
+#[derive(Default, Clone)]
+pub struct GenericStorage<VR: ValueReader> {
+    pub(crate) value_reader: VR,
+    // Caches first read and last write for a particular key.
+    pub(crate) internal_cache: StorageInternalCache,
+}
+
+impl<VR: ValueReader> Storage for GenericStorage<VR> {
+    fn get(&self, key: StorageKey) -> Option<StorageValue> {
+        self.internal_cache.get_or_fetch(key, &self.value_reader)
+    }
+
+    fn set(&mut self, key: StorageKey, value: StorageValue) {
+        self.internal_cache.set(key, value)
+    }
+
+    fn delete(&mut self, key: StorageKey) {
+        self.internal_cache.delete(key)
+    }
 }
 
 // Used only in tests.

--- a/sov-modules/sov-state/src/storage_test.rs
+++ b/sov-modules/sov-state/src/storage_test.rs
@@ -1,0 +1,30 @@
+use first_read_last_write_cache::cache::FirstReads;
+use std::collections::HashMap;
+
+use crate::{
+    storage::{StorageKey, StorageValue},
+    Storage, ZkStorage,
+};
+
+#[test]
+fn test_value_absent_in_zk_storage() {
+    let key = StorageKey::from("key");
+    let value = StorageValue::from("value");
+
+    // TODO: For now we crate the FirstReads manually. Once we have
+    // JmtDB ready, we should update the test to use JmtStorage instead.
+    let reads = make_reads(key.clone(), value.clone());
+
+    // Here we crate a new ZkStorage with an empty inner cache.
+    let storage = ZkStorage::new(reads);
+    // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
+    // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
+    let retrieved_value = storage.get(key).unwrap();
+    assert_eq!(value, retrieved_value);
+}
+
+fn make_reads(key: StorageKey, value: StorageValue) -> FirstReads {
+    let mut reads = HashMap::default();
+    reads.insert(key.as_cache_key(), value.as_cache_value());
+    FirstReads::new(reads)
+}

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -4,7 +4,6 @@ use sovereign_sdk::serial::{Decode, Encode};
 // SingletonKey is very similar to the unit type `()` i.e. it has only one value.
 // We provide a custom efficient Encode implementation for SingletonKey while Encode for `()`
 // is likely already implemented by an external library (like borsh), which is outside of our control.
-
 #[derive(Debug)]
 pub struct SingletonKey;
 

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -1,32 +1,38 @@
 use first_read_last_write_cache::cache::{self, FirstReads};
 
 use crate::{
-    internal_cache::{Cache, ValueReader},
+    internal_cache::{StorageInternalCache, ValueReader},
     storage::{StorageKey, StorageValue},
     Storage,
 };
 
+// Implementation of `ValueReader` trait for the zk-context. FirstReads is backed by a HashMap internally,
+// this is a good default choice. Once we start integrating with a proving system
+// we might want to explore other alternatives. For example in Risc0 we could implement `ValueReader`
+// in terms of `env::read()` and fetch values lazily from the host.
 impl ValueReader for FirstReads {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
         let key = key.as_cache_key();
-        match self.read(&key) {
-            cache::ExistsInCache::Yes(read) => read.value.map(|v| StorageValue { value: v }),
-            cache::ExistsInCache::No => panic!("todo"),
+        match self.get(&key) {
+            cache::ValueExists::Yes(read) => read.value.map(|v| StorageValue { value: v }),
+            // It is ok to panic here, `ZkStorage` must be able to access all the keys it needs.
+            cache::ValueExists::No => panic!("Error: Key {key:?} is inaccessible"),
         }
     }
 }
 
+/// Storage that can be used in Zk context.
 #[derive(Default, Clone)]
 pub struct ZkStorage {
     // Caches first read and last write for a particular key.
-    cache: Cache,
+    internal_cache: StorageInternalCache,
     first_reads: FirstReads,
 }
 
 impl ZkStorage {
     pub fn new(first_reads: FirstReads) -> Self {
         Self {
-            cache: Cache::default(),
+            internal_cache: StorageInternalCache::default(),
             first_reads,
         }
     }
@@ -34,14 +40,14 @@ impl ZkStorage {
 
 impl Storage for ZkStorage {
     fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.cache.get(key, &self.first_reads)
+        self.internal_cache.get_or_fetch(key, &self.first_reads)
     }
 
     fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.cache.set(key, value)
+        self.internal_cache.set(key, value)
     }
 
     fn delete(&mut self, key: StorageKey) {
-        self.cache.delete(key)
+        self.internal_cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -2,8 +2,7 @@ use first_read_last_write_cache::cache::{self, FirstReads};
 
 use crate::{
     internal_cache::{StorageInternalCache, ValueReader},
-    storage::{StorageKey, StorageValue},
-    Storage,
+    storage::{GenericStorage, StorageKey, StorageValue},
 };
 
 // Implementation of `ValueReader` trait for the zk-context. FirstReads is backed by a HashMap internally,
@@ -22,32 +21,13 @@ impl ValueReader for FirstReads {
 }
 
 /// Storage that can be used in zk-context.
-#[derive(Default, Clone)]
-pub struct ZkStorage {
-    // Caches first read and last write for a particular key.
-    internal_cache: StorageInternalCache,
-    first_reads: FirstReads,
-}
+pub type ZkStorage = GenericStorage<FirstReads>;
 
 impl ZkStorage {
     pub fn new(first_reads: FirstReads) -> Self {
         Self {
             internal_cache: StorageInternalCache::default(),
-            first_reads,
+            value_reader: first_reads,
         }
-    }
-}
-
-impl Storage for ZkStorage {
-    fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.internal_cache.get_or_fetch(key, &self.first_reads)
-    }
-
-    fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.internal_cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: StorageKey) {
-        self.internal_cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -8,7 +8,7 @@ use crate::{
 
 // Implementation of `ValueReader` trait for the zk-context. FirstReads is backed by a HashMap internally,
 // this is a good default choice. Once we start integrating with a proving system
-// we might want to explore other alternatives. For example in Risc0 we could implement `ValueReader`
+// we might want to explore other alternatives. For example, in Risc0 we could implement `ValueReader`
 // in terms of `env::read()` and fetch values lazily from the host.
 impl ValueReader for FirstReads {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
@@ -21,7 +21,7 @@ impl ValueReader for FirstReads {
     }
 }
 
-/// Storage that can be used in Zk context.
+/// Storage that can be used in zk-context.
 #[derive(Default, Clone)]
 pub struct ZkStorage {
     // Caches first read and last write for a particular key.

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -1,13 +1,13 @@
 use first_read_last_write_cache::cache::{self, FirstReads};
 
 use crate::{
-    internal_cache::{Cache, GetValue},
+    internal_cache::{Cache, ValueReader},
     storage::{StorageKey, StorageValue},
     Storage,
 };
 
-impl GetValue for FirstReads {
-    fn get_value(&self, key: StorageKey) -> Option<StorageValue> {
+impl ValueReader for FirstReads {
+    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
         let key = key.as_cache_key();
         match self.read(&key) {
             cache::ExistsInCache::Yes(read) => read.value.map(|v| StorageValue { value: v }),

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -1,0 +1,47 @@
+use first_read_last_write_cache::cache::{self, FirstReads};
+
+use crate::{
+    internal_cache::{Cache, GetValue},
+    storage::{StorageKey, StorageValue},
+    Storage,
+};
+
+impl GetValue for FirstReads {
+    fn get_value(&self, key: StorageKey) -> Option<StorageValue> {
+        let key = key.as_cache_key();
+        match self.read(&key) {
+            cache::ExistsInCache::Yes(read) => read.value.map(|v| StorageValue { value: v }),
+            cache::ExistsInCache::No => panic!("todo"),
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct ZkStorage {
+    // Caches first read and last write for a particular key.
+    cache: Cache,
+    first_reads: FirstReads,
+}
+
+impl ZkStorage {
+    pub fn new(first_reads: FirstReads) -> Self {
+        Self {
+            cache: Cache::default(),
+            first_reads,
+        }
+    }
+}
+
+impl Storage for ZkStorage {
+    fn get(&self, key: StorageKey) -> Option<StorageValue> {
+        self.cache.get(key, &self.first_reads)
+    }
+
+    fn set(&mut self, key: StorageKey, value: StorageValue) {
+        self.cache.set(key, value)
+    }
+
+    fn delete(&mut self, key: StorageKey) {
+        self.cache.delete(key)
+    }
+}


### PR DESCRIPTION
**Overview:** 

The first time a value is accessed from a module, it has to be loaded from an external source.
If a rollup runs in `native` context the external source will be a database. In `zk` context the first accessed values will appear "out of thin air" (for example, via the `env::read()` mechanism in Risc0)

This PR introduces the following changes:
1. `ValueReader` trait & `FirstReads` struct: encapsulate the code representing "external source".
2. Implementation for `ZkStorage` & `JmtStorage` using the `ValueReader ` trait.
3. Test update to reflect the above changes.

close #36