### PR TITLE
Ergonomics: Better return type for `query_value ` in `query.rs`

### DIFF
--- a/sov-modules/sov-modules-impl/src/example_simple_module/mod.rs
+++ b/sov-modules/sov-modules-impl/src/example_simple_module/mod.rs
@@ -48,7 +48,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueAdderModule<C
     #[cfg(feature = "native")]
     fn query(&self, msg: Self::QueryMessage) -> sov_modules_api::QueryResponse {
         match msg {
-            QueryMessage::GetValue => self.query_value(),
+            QueryMessage::GetValue => {
+                let response = serde_json::to_vec(&self.query_value()).unwrap();
+                sov_modules_api::QueryResponse { response }
+            }
         }
     }
 }

--- a/sov-modules/sov-modules-impl/src/example_simple_module/query.rs
+++ b/sov-modules/sov-modules-impl/src/example_simple_module/query.rs
@@ -1,6 +1,5 @@
 use super::ValueAdderModule;
 use serde::{Deserialize, Serialize};
-use sov_modules_api::QueryResponse;
 use sovereign_sdk::serial::{Decode, DecodeBorrowed};
 
 pub enum QueryMessage {
@@ -14,13 +13,10 @@ pub struct Response {
 
 impl<C: sov_modules_api::Context> ValueAdderModule<C> {
     /// Queries the state of the module.
-    pub fn query_value(&self) -> QueryResponse {
-        let response = Response {
+    pub fn query_value(&self) -> Response {
+        Response {
             value: self.value.get(),
-        };
-
-        let response = serde_json::to_vec(&response).unwrap();
-        QueryResponse { response }
+        }
     }
 }
 


### PR DESCRIPTION
The old way of handling return value is unnecessarily redundant.