### PR TITLE
docs: fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ look at the contents of the [`sdk`](sdk) folder
 
 ## How does it work?
 
-To learn how the Sovereign SDK works, see the ![Sovereign SDK Overview](sdk/specs/overview.md).
+To learn how the Sovereign SDK works, see the [Sovereign SDK Overview](sdk/specs/overview.md).
 
 ## Warning
 


### PR DESCRIPTION
The link to the Sovereign SDK Overview isn't an image so it doesn't need the preceding `!`

Before | After
--- | ---
<img width="275" alt="Screenshot 2023-02-15 at 12 27 51 PM" src="https://user-images.githubusercontent.com/3699047/219106594-b5d18e17-3f25-4f8b-ba16-24f21291a224.png"> | <img width="256" alt="Screenshot 2023-02-15 at 12 28 18 PM" src="https://user-images.githubusercontent.com/3699047/219106750-017b1a10-47eb-4214-b8cb-9b59c0922bc8.png">
