### PR TITLE
Refactor CacheValue type

### DIFF
--- a/first-read-last-write-cache/src/lib.rs
+++ b/first-read-last-write-cache/src/lib.rs
@@ -21,13 +21,7 @@ impl Display for CacheKey {
 
 #[derive(Error, Debug, Eq, PartialEq, Clone)]
 pub struct CacheValue {
-    pub value: Option<Arc<Vec<u8>>>,
-}
-
-impl CacheValue {
-    pub fn empty() -> Self {
-        Self { value: None }
-    }
+    pub value: Arc<Vec<u8>>,
 }
 
 impl Display for CacheValue {

--- a/first-read-last-write-cache/src/utils.rs
+++ b/first-read-last-write-cache/src/utils.rs
@@ -10,9 +10,9 @@ pub mod test_util {
         }
     }
 
-    pub(crate) fn create_value(v: u8) -> CacheValue {
-        CacheValue {
-            value: Some(Arc::new(vec![v])),
-        }
+    pub(crate) fn create_value(v: u8) -> Option<CacheValue> {
+        Some(CacheValue {
+            value: Arc::new(vec![v]),
+        })
     }
 }

--- a/sov-modules/sov-state/src/backend.rs
+++ b/sov-modules/sov-state/src/backend.rs
@@ -33,12 +33,11 @@ impl<K: Encode, V: Encode + Decode, S: Storage> Backend<K, V, S> {
     }
 
     pub(crate) fn get_value(&self, storage_key: StorageKey) -> Option<V> {
-        let storage_value = self.storage.get(storage_key)?.value;
+        let storage_value = self.storage.get(storage_key)?;
 
-        let mut storage_reader: &[u8] = &storage_value;
         // It is ok to panic here. Deserialization problem means that something is terribly wrong.
         Some(
-            V::decode(&mut storage_reader)
+            V::decode(&mut storage_value.value())
                 .unwrap_or_else(|e| panic!("Unable to deserialize storage value {e:?}")),
         )
     }

--- a/sov-modules/sov-state/src/internal_cache.rs
+++ b/sov-modules/sov-state/src/internal_cache.rs
@@ -1,8 +1,5 @@
 use crate::storage::{StorageKey, StorageValue};
-use first_read_last_write_cache::{
-    cache::{self, CacheLog},
-    CacheValue,
-};
+use first_read_last_write_cache::cache::{self, CacheLog};
 use std::{cell::RefCell, rc::Rc};
 
 /// `ValueReader` Reads a value from an external data source.
@@ -36,23 +33,19 @@ impl StorageInternalCache {
                     // It is ok to panic here, we must guarantee that the cache is consistent.
                     .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
 
-                cache_value_exists.value.map(|value| StorageValue { value })
+                cache_value_exists.map(StorageValue::new_from_cache_value)
             }
             // If the value does not exist in the cache, then fetch it from an external source.
             cache::ValueExists::No => {
-                let value = value_reader.read_value(key);
-
-                let cache_value = CacheValue {
-                    value: value
-                        .as_ref()
-                        .map(|storage_value| storage_value.value.clone()),
-                };
+                let storage_value = value_reader.read_value(key);
+                let cache_value = storage_value.as_ref().map(|v| v.clone().as_cache_value());
 
                 self.cache
                     .borrow_mut()
                     .add_read(cache_key, cache_value)
                     .unwrap_or_else(|e| panic!("Inconsistent read from the cache: {e:?}"));
-                value
+
+                storage_value
             }
         }
     }
@@ -60,13 +53,13 @@ impl StorageInternalCache {
     pub(crate) fn set(&mut self, key: StorageKey, value: StorageValue) {
         let cache_key = key.as_cache_key();
         let cache_value = value.as_cache_value();
-        self.cache.borrow_mut().add_write(cache_key, cache_value);
+        self.cache
+            .borrow_mut()
+            .add_write(cache_key, Some(cache_value));
     }
 
     pub(crate) fn delete(&mut self, key: StorageKey) {
         let cache_key = key.as_cache_key();
-        self.cache
-            .borrow_mut()
-            .add_write(cache_key, CacheValue::empty());
+        self.cache.borrow_mut().add_write(cache_key, None);
     }
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -53,7 +53,7 @@ impl StorageKey {
 // `Value` type for the `Storage`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StorageValue {
-    pub value: Arc<Vec<u8>>,
+    value: Arc<Vec<u8>>,
 }
 
 impl StorageValue {
@@ -65,9 +65,17 @@ impl StorageValue {
         }
     }
 
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+
     pub fn as_cache_value(self) -> CacheValue {
-        CacheValue {
-            value: Some(self.value),
+        CacheValue { value: self.value }
+    }
+
+    pub fn new_from_cache_value(cache_value: CacheValue) -> Self {
+        Self {
+            value: cache_value.value,
         }
     }
 }

--- a/sov-modules/sov-state/src/storage_test.rs
+++ b/sov-modules/sov-state/src/storage_test.rs
@@ -9,7 +9,7 @@ use crate::{
 #[test]
 fn test_value_absent_in_zk_storage() {
     let key = StorageKey::from("key");
-    let value = StorageValue::from("value");
+    let value = Some(StorageValue::from("value"));
 
     // TODO: For now we crate the FirstReads manually. Once we have
     // JmtDB ready, we should update the test to use JmtStorage instead.
@@ -19,12 +19,12 @@ fn test_value_absent_in_zk_storage() {
     let storage = ZkStorage::new(reads);
     // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
     // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
-    let retrieved_value = storage.get(key).unwrap();
+    let retrieved_value = storage.get(key);
     assert_eq!(value, retrieved_value);
 }
 
-fn make_reads(key: StorageKey, value: StorageValue) -> FirstReads {
+fn make_reads(key: StorageKey, value: Option<StorageValue>) -> FirstReads {
     let mut reads = HashMap::default();
-    reads.insert(key.as_cache_key(), value.as_cache_value());
+    reads.insert(key.as_cache_key(), value.map(|v| v.as_cache_value()));
     FirstReads::new(reads)
 }

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -13,7 +13,7 @@ impl ValueReader for FirstReads {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
         let key = key.as_cache_key();
         match self.get(&key) {
-            cache::ValueExists::Yes(read) => read.value.map(|v| StorageValue { value: v }),
+            cache::ValueExists::Yes(read) => read.map(StorageValue::new_from_cache_value),
             // It is ok to panic here, `ZkStorage` must be able to access all the keys it needs.
             cache::ValueExists::No => panic!("Error: Key {key:?} is inaccessible"),
         }


### PR DESCRIPTION
This PR makes the following change:

The `CacheValue` type is defined as follow:
```
pub struct CacheValue {
    pub value: Option<Arc<Vec<u8>>>,
}
```
And the `StorageValue` type:
```
pub struct StorageValue {
    value: Arc<Vec<u8>>,
}
```

These two types have a similar purpose, and often we need to convert one to another. Therefore, it makes sense to remove the `Option` wrapper from `CacheValue` struct and simplify the conversions. After this change we will pass around  `Option<CacheValue>` instead of `CacheValue`. 

In the future, we may replace these two structs with a common type.