### PR TITLE
modules: get on state variables returns `Result` instead of `Option`

### DIFF
--- a/sov-modules/sov-modules-impl/example-election/Cargo.toml
+++ b/sov-modules/sov-modules-impl/example-election/Cargo.toml
@@ -13,9 +13,10 @@ sov-modules-macros = { workspace = true }
 sov-state = { workspace = true }
 sovereign-sdk = { workspace = true }
 serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true}
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 borsh = { workspace = true, features = ["rc"]}
+hex = { workspace = true }
 
 [features]
 default = ["native"]

--- a/sov-modules/sov-modules-impl/example-election/src/call.rs
+++ b/sov-modules/sov-modules-impl/example-election/src/call.rs
@@ -60,17 +60,14 @@ impl<C: sov_modules_api::Context> Election<C> {
     ) -> Result<CallResponse> {
         self.exit_if_frozen()?;
 
-        let voter = self
-            .allowed_voters
-            .get(context.sender())
-            .ok_or(anyhow!("Voter missing from the allowed list."))?;
+        let voter = self.allowed_voters.get(context.sender())?;
 
         match voter {
             Voter::Voted => bail!("Voter tried voting a second time!"),
             Voter::Fresh => {
                 self.allowed_voters.set(context.sender(), Voter::voted());
 
-                let mut candidates = self.get_candidates()?;
+                let mut candidates = self.candidates.get()?;
 
                 // Check if a candidate exist.
                 let candidate = candidates
@@ -102,7 +99,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_not_admin(&self, context: &C) -> Result<()> {
-        let admin = self.admin.get().ok_or(anyhow!("Admin is not registered"))?;
+        let admin = self.admin.get()?;
 
         ensure!(
             &admin == context.sender(),
@@ -112,10 +109,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_frozen(&self) -> Result<()> {
-        let is_frozen = self
-            .is_frozen
-            .get()
-            .ok_or(anyhow!("Frozen value is not set."))?;
+        let is_frozen = self.is_frozen.get()?;
 
         if is_frozen {
             bail!("Election is frozen.")
@@ -125,21 +119,15 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_candidates_already_set(&self) -> Result<()> {
-        ensure!(self.candidates.get().is_none(), "Candidate already set.");
+        ensure!(self.candidates.get().is_err(), "Candidate already set.");
         Ok(())
     }
 
     fn exit_if_voter_already_set(&self, voter_pub_key: &C::PublicKey) -> Result<()> {
         ensure!(
-            self.allowed_voters.get(voter_pub_key).is_none(),
+            self.allowed_voters.get(voter_pub_key).is_err(),
             "Voter already has the right to vote."
         );
         Ok(())
-    }
-
-    fn get_candidates(&self) -> Result<Vec<Candidate>> {
-        self.candidates
-            .get()
-            .ok_or(anyhow!("Candidate not registered."))
     }
 }

--- a/sov-modules/sov-modules-impl/example-election/src/call.rs
+++ b/sov-modules/sov-modules-impl/example-election/src/call.rs
@@ -60,14 +60,14 @@ impl<C: sov_modules_api::Context> Election<C> {
     ) -> Result<CallResponse> {
         self.exit_if_frozen()?;
 
-        let voter = self.allowed_voters.get(context.sender())?;
+        let voter = self.allowed_voters.get_or_err(context.sender())?;
 
         match voter {
             Voter::Voted => bail!("Voter tried voting a second time!"),
             Voter::Fresh => {
                 self.allowed_voters.set(context.sender(), Voter::voted());
 
-                let mut candidates = self.candidates.get()?;
+                let mut candidates = self.candidates.get_or_err()?;
 
                 // Check if a candidate exist.
                 let candidate = candidates
@@ -99,7 +99,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_not_admin(&self, context: &C) -> Result<()> {
-        let admin = self.admin.get()?;
+        let admin = self.admin.get_or_err()?;
 
         ensure!(
             &admin == context.sender(),
@@ -109,7 +109,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_frozen(&self) -> Result<()> {
-        let is_frozen = self.is_frozen.get()?;
+        let is_frozen = self.is_frozen.get_or_err()?;
 
         if is_frozen {
             bail!("Election is frozen.")
@@ -119,13 +119,13 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     fn exit_if_candidates_already_set(&self) -> Result<()> {
-        ensure!(self.candidates.get().is_err(), "Candidate already set.");
+        ensure!(self.candidates.get().is_none(), "Candidate already set.");
         Ok(())
     }
 
     fn exit_if_voter_already_set(&self, voter_pub_key: &C::PublicKey) -> Result<()> {
         ensure!(
-            self.allowed_voters.get(voter_pub_key).is_err(),
+            self.allowed_voters.get(voter_pub_key).is_none(),
             "Voter already has the right to vote."
         );
         Ok(())

--- a/sov-modules/sov-modules-impl/example-value-adder/src/call.rs
+++ b/sov-modules/sov-modules-impl/example-value-adder/src/call.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use borsh::BorshDeserialize;
 use sov_modules_api::CallResponse;
 use std::fmt::Debug;
@@ -31,11 +31,7 @@ impl<C: sov_modules_api::Context> ValueAdderModule<C> {
     ) -> Result<sov_modules_api::CallResponse> {
         let mut response = CallResponse::default();
 
-        let admin = match self.admin.get() {
-            Some(admin) => admin,
-            // Here we use &str as an error.
-            None => bail!("Admin is not set"),
-        };
+        let admin = self.admin.get()?;
 
         if &admin != context.sender() {
             // Here we use a custom error type.

--- a/sov-modules/sov-modules-impl/example-value-adder/src/call.rs
+++ b/sov-modules/sov-modules-impl/example-value-adder/src/call.rs
@@ -31,7 +31,7 @@ impl<C: sov_modules_api::Context> ValueAdderModule<C> {
     ) -> Result<sov_modules_api::CallResponse> {
         let mut response = CallResponse::default();
 
-        let admin = self.admin.get()?;
+        let admin = self.admin.get_or_err()?;
 
         if &admin != context.sender() {
             // Here we use a custom error type.

--- a/sov-modules/sov-modules-impl/example-value-adder/src/query.rs
+++ b/sov-modules/sov-modules-impl/example-value-adder/src/query.rs
@@ -16,7 +16,7 @@ impl<C: sov_modules_api::Context> ValueAdderModule<C> {
     /// Queries the state of the module.
     pub fn query_value(&self) -> Response {
         Response {
-            value: self.value.get().ok(),
+            value: self.value.get(),
         }
     }
 }

--- a/sov-modules/sov-modules-impl/example-value-adder/src/query.rs
+++ b/sov-modules/sov-modules-impl/example-value-adder/src/query.rs
@@ -16,7 +16,7 @@ impl<C: sov_modules_api::Context> ValueAdderModule<C> {
     /// Queries the state of the module.
     pub fn query_value(&self) -> Response {
         Response {
-            value: self.value.get(),
+            value: self.value.get().ok(),
         }
     }
 }

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 [dependencies]
 # TODO remove this dependency once the  Decode/Encode traits are extracted to a separate crate.
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 sovereign-sdk = { workspace = true }
 first-read-last-write-cache = { workspace = true }
 jellyfish-merkle-generic = { workspace = true }
-
+hex = { workspace = true}

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -12,6 +12,7 @@ mod storage_test;
 
 pub use jmt_storage::JmtStorage;
 pub use map::StateMap;
+use std::{fmt::Display, str};
 pub use storage::Storage;
 use utils::AlignedVec;
 pub use zk_storage::ZkStorage;
@@ -22,9 +23,16 @@ pub use value::StateValue;
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
 // to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique
 // prefix that is prepended to each key.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Prefix {
     prefix: AlignedVec,
+}
+
+impl Display for Prefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let buf = self.prefix.as_ref();
+        write!(f, "{:?}", str::from_utf8(buf).unwrap())
+    }
 }
 
 impl Prefix {

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -28,12 +28,18 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
         self.backend.set_value(storage_key, value)
     }
 
-    /// Returns the value corresponding to the key or Error if key is absent in the StateMap.
-    pub fn get(&self, key: &K) -> Result<V, Error> {
+    /// Returns the value corresponding to the key or None if key is absent in the StateMap.
+    pub fn get(&self, key: &K) -> Option<V> {
         let storage_key = StorageKey::new(self.backend.prefix(), key);
-        self.backend
-            .get_value(storage_key.clone())
-            .ok_or(Error::MissingValue(self.prefix().clone(), storage_key))
+        self.backend.get_value(storage_key)
+    }
+
+    /// Returns the value corresponding to the key or Error if key is absent in the StateMap.
+    pub fn get_or_err(&self, key: &K) -> Result<V, Error> {
+        self.get(key).ok_or(Error::MissingValue(
+            self.prefix().clone(),
+            StorageKey::new(self.backend.prefix(), key),
+        ))
     }
 
     pub fn prefix(&self) -> &Prefix {

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -24,13 +24,13 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
 
     /// Inserts a key-value pair into the map.
     pub fn set(&mut self, key: &K, value: V) {
-        let storage_key = StorageKey::new(self.backend.prefix(), key);
+        let storage_key = StorageKey::new(self.prefix(), key);
         self.backend.set_value(storage_key, value)
     }
 
     /// Returns the value corresponding to the key or None if key is absent in the StateMap.
     pub fn get(&self, key: &K) -> Option<V> {
-        let storage_key = StorageKey::new(self.backend.prefix(), key);
+        let storage_key = StorageKey::new(self.prefix(), key);
         self.backend.get_value(storage_key)
     }
 
@@ -38,7 +38,7 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     pub fn get_or_err(&self, key: &K) -> Result<V, Error> {
         self.get(key).ok_or(Error::MissingValue(
             self.prefix().clone(),
-            StorageKey::new(self.backend.prefix(), key),
+            StorageKey::new(self.prefix(), key),
         ))
     }
 

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -8,9 +8,10 @@ pub struct StateMap<K, V, S> {
     backend: Backend<K, V, S>,
 }
 
+/// Error type for `StateMap` get method.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Value not found for prefix: {0} and storage key {1}")]
+    #[error("Value not found for prefix: {0} and: storage key {1}")]
     MissingValue(Prefix, StorageKey),
 }
 

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -1,10 +1,17 @@
 use crate::{backend::Backend, storage::StorageKey, Prefix, Storage};
 use sovereign_sdk::serial::{Decode, Encode};
+use thiserror::Error;
 
 /// A container that maps keys to values.
 #[derive(Debug)]
 pub struct StateMap<K, V, S> {
     backend: Backend<K, V, S>,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Value not found for prefix: {0} and storage key {1}")]
+    MissingValue(Prefix, StorageKey),
 }
 
 impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
@@ -20,10 +27,12 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
         self.backend.set_value(storage_key, value)
     }
 
-    /// Returns the value corresponding to the key or None if key is absent in the StateMap.
-    pub fn get(&self, key: &K) -> Option<V> {
+    /// Returns the value corresponding to the key or Error if key is absent in the StateMap.
+    pub fn get(&self, key: &K) -> Result<V, Error> {
         let storage_key = StorageKey::new(self.backend.prefix(), key);
-        self.backend.get_value(storage_key)
+        self.backend
+            .get_value(storage_key.clone())
+            .ok_or(Error::MissingValue(self.prefix().clone(), storage_key))
     }
 
     pub fn prefix(&self) -> &Prefix {

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -1,16 +1,16 @@
-use std::sync::Arc;
-
-use first_read_last_write_cache::{CacheKey, CacheValue};
-use sovereign_sdk::serial::Encode;
+use std::{fmt::Display, sync::Arc};
 
 use crate::{
     internal_cache::{StorageInternalCache, ValueReader},
     utils::AlignedVec,
     Prefix,
 };
+use first_read_last_write_cache::{CacheKey, CacheValue};
+use hex;
+use sovereign_sdk::serial::Encode;
 
 // `Key` type for the `Storage`
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StorageKey {
     key: Arc<Vec<u8>>,
 }
@@ -28,6 +28,12 @@ impl StorageKey {
 impl AsRef<Vec<u8>> for StorageKey {
     fn as_ref(&self) -> &Vec<u8> {
         &self.key
+    }
+}
+
+impl Display for StorageKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x?}", hex::encode(self.key().as_ref()))
     }
 }
 

--- a/sov-modules/sov-state/src/utils.rs
+++ b/sov-modules/sov-state/src/utils.rs
@@ -2,7 +2,7 @@
 // This makes certain operations cheaper in zk-context (concatenation)
 // TODO: Currently the implementation defaults to `stc::vec::Vec` see:
 // https://github.com/Sovereign-Labs/sovereign/issues/47
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AlignedVec {
     inner: Vec<u8>,
 }

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -43,12 +43,15 @@ impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
         self.backend.set_value(storage_key, value)
     }
 
-    /// Gets a value from the StateValue or Error if the value is absent.
-    pub fn get(&self) -> Result<V, Error> {
+    /// Gets a value from the StateValue or None if the value is absent.
+    pub fn get(&self) -> Option<V> {
         let storage_key = StorageKey::new(self.backend.prefix(), &SingletonKey);
-        self.backend
-            .get_value(storage_key)
-            .ok_or(Error::MissingValue(self.prefix().clone()))
+        self.backend.get_value(storage_key)
+    }
+
+    /// Gets a value from the StateValue or Error if the value is absent.
+    pub fn get_or_err(&self) -> Result<V, Error> {
+        self.get().ok_or(Error::MissingValue(self.prefix().clone()))
     }
 
     pub fn prefix(&self) -> &Prefix {

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -21,6 +21,7 @@ pub struct StateValue<V, S> {
     backend: Backend<SingletonKey, V, S>,
 }
 
+/// Error type for `StateValue` get method.
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Value not found for prefix: {0}")]


### PR DESCRIPTION
The `get` method for state variables returns  `Option`, but the module methods return `Result`. This means that we have to use `ok_or` to get a value from the storage. 
```
let value = self.some_varable.get().ok_or("anyhow!("some error message")")?;
```
This is not very ergonomic. The idea is to cheng the signature of `get` method to return  `Result`. 
This way, developers can write:

```
let value = self.some_varable.get()?;
```
 

