### PR TITLE
Remove unnecessary code from module_info.rs

### DIFF
--- a/sov-modules/sov-modules-macros/src/lib.rs
+++ b/sov-modules/sov-modules-macros/src/lib.rs
@@ -4,7 +4,7 @@ use dispatch::genesis::GenesisMacro;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
-/// Macro generating a `_new` method and prefixes for the underlying sov-module.
+/// Derives the `sov-modules-api::ModuleInfo` implementation for the underlying type.
 ///
 /// See `sov-modules-api` for definition of `prefix`.
 /// ## Example
@@ -21,7 +21,7 @@ use syn::parse_macro_input;
 /// ```
 /// allows getting a prefix of a member field like:
 /// ```ignore
-///  let test_struct = test_module::TestModule::<SomeContext>::_new(some_storage);
+///  let test_struct = <TestModule::<SomeContext> as sov_modules_api::ModuleInfo<SomeContext>>::new(some_storage);
 ///  let prefix1 = test_struct.test_state1.prefix;
 /// ````
 /// ## Attributes

--- a/sov-modules/sov-modules-macros/src/module_info.rs
+++ b/sov-modules/sov-modules-macros/src/module_info.rs
@@ -237,28 +237,7 @@ fn make_init_module<'a>(
     let field_ident = &field.ident;
     let ty = &field.ty;
 
-    let ty = match ty {
-        syn::Type::Path(syn::TypePath { path, .. }) => {
-            let mut segments = path.segments.clone();
-
-            let last = segments
-                .last_mut()
-                .expect("Impossible happened! A type path has no segments");
-
-            // Remove generics for the type SomeType<G> => SomeType
-            last.arguments = PathArguments::None;
-            segments
-        }
-
-        _ => {
-            return Err(syn::Error::new_spanned(
-                ty,
-                "Type not supported by the `ModuleInfo` macro",
-            ));
-        }
-    };
-
     Ok(quote::quote! {
-        let #field_ident = <#ty #type_generics as sov_modules_api::ModuleInfo #type_generics>::new(storage.clone());
+        let #field_ident = <#ty as sov_modules_api::ModuleInfo #type_generics>::new(storage.clone());
     })
 }


### PR DESCRIPTION
While working on `derive(Genesis)` I realized we don't have to remove the `generics` when instantiating a module. 
This PR fixes it for the `ModuleInfo` macro.