### PR TITLE
Update borsh to v0.10.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "2475dfb7b73bf16
 
 # External dependencies
 anyhow = "1.0.68"
-borsh = { version = "0.10.0", features = ["rc"]}
+borsh = { version = "0.10.2", features = ["rc"]}
 byteorder = "1.4.3"
 bytes = "1.2.1"
 hex = "0.4.3"


### PR DESCRIPTION
Updating borsh to `0.10.2`, we need (de)ser for `core::ops::range` which was introduced in `0.10.1`:
https://github.com/near/borsh-rs/releases/tag/v0.10.1


