### PR TITLE
Update db encoding traits. Revise JMT value schema.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
+	"db/schemadb",
+	"db/sovereign-db",
 	"sdk",
 	"first-read-last-write-cache",
 	"sov-modules/sov-modules-macros",
@@ -12,11 +14,22 @@ members = [
 
 ]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Sovereign Labs <info@sovereign.xyz>"]
+homepage = "sovereign.xyz"
+publish = false
+repository = "https://github.com/sovereign-labs/sovereign"
+rust-version = "1.67"
 
 [workspace.dependencies]
 # Internal dependencies
 sovereign-sdk = {path= "sdk" }
 first-read-last-write-cache = {path = "first-read-last-write-cache"}
+schemadb = {path = "db/schemadb"}
+sovereign-db = {path = "db/sovereign-db"}
 sov-state = {path = "sov-modules/sov-state"}
 sov-modules-api = {path = "sov-modules/sov-modules-api"}
 sov-modules-macros = {path = "sov-modules/sov-modules-macros"}
@@ -36,8 +49,10 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 rand = "0.8"
 rayon = "1.5.2"
+rocksdb =  { version = "0.19.0", features = ["lz4"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = { version = "1.0"}
 sha2 = "0.10.6"
 thiserror = "1.0.38"
 tiny-keccak = "2.0.2"
+tracing = "0.1.37"

--- a/db/schemadb/Cargo.toml
+++ b/db/schemadb/Cargo.toml
@@ -22,7 +22,15 @@ prometheus = { workspace = true }
 rocksdb = { workspace = true }
 tracing = { workspace = true }
 
+# Temppath external dependencies
+byteorder = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+
 [dev-dependencies]
-byteorder = "1.4.3"
-rand = "0.7.3"
-hex = "0.4.3"
+byteorder = { workspace = true }
+rand = { workspace = true }
+hex = { workspace = true }
+[features]
+default = []
+temppath = ["dep:byteorder", "dep:rand", "dep:hex"]

--- a/db/schemadb/src/db_test.rs
+++ b/db/schemadb/src/db_test.rs
@@ -4,7 +4,7 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 use sovereign_sdk::{
-    db::{errors::CodecError, ColumnFamilyName, KeyCodec, Result, ValueCodec},
+    db::{errors::CodecError, ColumnFamilyName, KeyDecoder, KeyEncoder, Result, ValueCodec},
     define_schema,
 };
 
@@ -35,11 +35,13 @@ impl TestField {
     }
 }
 
-impl KeyCodec<TestSchema1> for TestField {
+impl KeyEncoder<TestSchema1> for TestField {
     fn encode_key(&self) -> Result<Vec<u8>> {
         Ok(self.to_bytes())
     }
+}
 
+impl KeyDecoder<TestSchema1> for TestField {
     fn decode_key(data: &[u8]) -> Result<Self> {
         Self::from_bytes(data)
     }
@@ -55,11 +57,13 @@ impl ValueCodec<TestSchema1> for TestField {
     }
 }
 
-impl KeyCodec<TestSchema2> for TestField {
+impl KeyEncoder<TestSchema2> for TestField {
     fn encode_key(&self) -> Result<Vec<u8>> {
         Ok(self.to_bytes())
     }
+}
 
+impl KeyDecoder<TestSchema2> for TestField {
     fn decode_key(data: &[u8]) -> Result<Self> {
         Self::from_bytes(data)
     }
@@ -177,9 +181,7 @@ fn test_schema_put_get() {
 }
 
 fn collect_values<S: Schema>(db: &TestDB) -> Vec<(S::Key, S::Value)> {
-    let mut iter = db
-        .iter::<S>(Default::default())
-        .expect("Failed to create iterator.");
+    let mut iter = db.iter::<S>().expect("Failed to create iterator.");
     iter.seek_to_first();
     iter.collect::<Result<Vec<_>, anyhow::Error>>().unwrap()
 }

--- a/db/schemadb/src/lib.rs
+++ b/db/schemadb/src/lib.rs
@@ -319,7 +319,7 @@ fn default_write_options() -> rocksdb::WriteOptions {
     opts
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "temppath"))]
 pub mod temppath {
     // Adapted from aptos temppath
 

--- a/db/schemadb/src/lib.rs
+++ b/db/schemadb/src/lib.rs
@@ -32,9 +32,9 @@ pub mod iterator;
 mod metrics;
 
 #[cfg(test)]
-mod iterator_test;
-#[cfg(test)]
 mod db_test;
+#[cfg(test)]
+mod iterator_test;
 
 #[derive(Debug)]
 enum WriteOp {
@@ -64,12 +64,12 @@ impl SchemaBatch {
     }
 
     /// Adds an insert/update operation to the batch.
-    pub fn put<S: Schema>(&self, key: &S::Key, value: &S::Value) -> Result<()> {
+    pub fn put<S: Schema>(&self, key: &impl KeyCodec<S>, value: &impl ValueCodec<S>) -> Result<()> {
         let _timer = SCHEMADB_BATCH_PUT_LATENCY_SECONDS
             .with_label_values(&["unknown"])
             .start_timer();
-        let key = <S::Key as KeyCodec<S>>::encode_key(key)?;
-        let value = <S::Value as ValueCodec<S>>::encode_value(value)?;
+        let key = key.encode_key()?;
+        let value = value.encode_value()?;
         self.rows
             .lock()
             .expect("Lock must not be poisoned")
@@ -81,8 +81,8 @@ impl SchemaBatch {
     }
 
     /// Adds a delete operation to the batch.
-    pub fn delete<S: Schema>(&self, key: &S::Key) -> Result<()> {
-        let key = <S::Key as KeyCodec<S>>::encode_key(key)?;
+    pub fn delete<S: Schema>(&self, key: &impl KeyCodec<S>) -> Result<()> {
+        let key = key.encode_key()?;
         self.rows
             .lock()
             .expect("Lock must not be poisoned")
@@ -172,12 +172,12 @@ impl DB {
     }
 
     /// Reads single record by key.
-    pub fn get<S: Schema>(&self, schema_key: &S::Key) -> Result<Option<S::Value>> {
+    pub fn get<S: Schema>(&self, schema_key: &impl KeyCodec<S>) -> Result<Option<S::Value>> {
         let _timer = SCHEMADB_GET_LATENCY_SECONDS
             .with_label_values(&[S::COLUMN_FAMILY_NAME])
             .start_timer();
 
-        let k = <S::Key as KeyCodec<S>>::encode_key(schema_key)?;
+        let k = schema_key.encode_key()?;
         let cf_handle = self.get_cf_handle(S::COLUMN_FAMILY_NAME)?;
 
         let result = self.inner.get_cf(cf_handle, k)?;
@@ -192,7 +192,7 @@ impl DB {
     }
 
     /// Writes single record.
-    pub fn put<S: Schema>(&self, key: &S::Key, value: &S::Value) -> Result<()> {
+    pub fn put<S: Schema>(&self, key: &impl KeyCodec<S>, value: &impl ValueCodec<S>) -> Result<()> {
         // Not necessary to use a batch, but we'd like a central place to bump counters.
         // Used in tests only anyway.
         let batch = SchemaBatch::new();
@@ -212,13 +212,22 @@ impl DB {
         ))
     }
 
-    /// Returns a forward [`SchemaIterator`] on a certain schema.
-    pub fn iter<S: Schema>(&self, opts: ReadOptions) -> Result<SchemaIterator<S>> {
-        self.iter_with_direction::<S>(opts, ScanDirection::Forward)
+    /// Returns a forward [`SchemaIterator`] on a certain schema with the default read options.
+    pub fn iter<S: Schema>(&self) -> Result<SchemaIterator<S>> {
+        self.iter_with_direction::<S>(Default::default(), ScanDirection::Forward)
     }
 
-    /// Returns a backward [`SchemaIterator`] on a certain schema.
-    pub fn rev_iter<S: Schema>(&self, opts: ReadOptions) -> Result<SchemaIterator<S>> {
+    /// Returns a forward [`SchemaIterator`] on a certain schema with the provided read options.
+    pub fn iter_with_opts<S: Schema>(&self, opts: ReadOptions) -> Result<SchemaIterator<S>> {
+        self.iter_with_direction::<S>(opts, ScanDirection::Forward)
+    }
+    /// Returns a backward [`SchemaIterator`] on a certain schema with the default read options.
+    pub fn rev_iter<S: Schema>(&self) -> Result<SchemaIterator<S>> {
+        self.iter_with_direction::<S>(Default::default(), ScanDirection::Backward)
+    }
+
+    /// Returns a backward [`SchemaIterator`] on a certain schema with the provided read options.
+    pub fn rev_iter_with_opts<S: Schema>(&self, opts: ReadOptions) -> Result<SchemaIterator<S>> {
         self.iter_with_direction::<S>(opts, ScanDirection::Backward)
     }
 

--- a/db/sovereign-db/Cargo.toml
+++ b/db/sovereign-db/Cargo.toml
@@ -16,3 +16,12 @@ sovereign-sdk = { workspace = true }
 anyhow = { workspace = true }
 byteorder = { workspace = true }
 borsh = { workspace = true }
+rocksdb = { workspace = true }
+
+
+[dev-dependencies]
+schemadb = { workspace = true, features = ["temppath"] }
+
+[features]
+default = []
+temp = ["schemadb/temppath"]

--- a/db/sovereign-db/Cargo.toml
+++ b/db/sovereign-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # Maintained by sovereign labs
 jmt = { workspace = true }
 schemadb = { workspace = true }
-sovereign-sdk = { workspace = true, features = ["sync"] }
+sovereign-sdk = { workspace = true }
 
 
 # External

--- a/db/sovereign-db/src/lib.rs
+++ b/db/sovereign-db/src/lib.rs
@@ -1,5 +1,6 @@
 use state_db::StateDB;
 
+pub mod rocks_db_config;
 pub mod schema;
 pub mod state_db;
 

--- a/db/sovereign-db/src/rocks_db_config.rs
+++ b/db/sovereign-db/src/rocks_db_config.rs
@@ -1,0 +1,52 @@
+// Adapted from Aptos-Core.
+// Modified to remove serde dependency
+
+use rocksdb::Options;
+
+/// Port selected RocksDB options for tuning underlying rocksdb instance of our state db.
+/// The current default values are taken from Aptos. TODO: tune rocksdb for our workload.
+/// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
+/// for detailed explanations.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RocksdbConfig {
+    pub max_open_files: i32,
+    pub max_total_wal_size: u64,
+    pub max_background_jobs: i32,
+    pub block_cache_size: u64,
+    pub block_size: u64,
+    pub cache_index_and_filter_blocks: bool,
+}
+
+impl Default for RocksdbConfig {
+    fn default() -> Self {
+        Self {
+            // Allow db to close old sst files, saving memory.
+            max_open_files: 5000,
+            // For now we set the max total WAL size to be 1G. This config can be useful when column
+            // families are updated at non-uniform frequencies.
+            max_total_wal_size: 1u64 << 30,
+            // This includes threads for flashing and compaction. Rocksdb will decide the # of
+            // threads to use internally.
+            max_background_jobs: 16,
+            // Default block cache size is 8MB,
+            block_cache_size: 8 * (1u64 << 20),
+            // Default block cache size is 4KB,
+            block_size: 4 * (1u64 << 10),
+            // Whether cache index and filter blocks into block cache.
+            cache_index_and_filter_blocks: false,
+        }
+    }
+}
+
+pub fn gen_rocksdb_options(config: &RocksdbConfig, readonly: bool) -> Options {
+    let mut db_opts = Options::default();
+    db_opts.set_max_open_files(config.max_open_files);
+    db_opts.set_max_total_wal_size(config.max_total_wal_size);
+    db_opts.set_max_background_jobs(config.max_background_jobs);
+    if !readonly {
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+    }
+
+    db_opts
+}

--- a/db/sovereign-db/src/schema/types.rs
+++ b/db/sovereign-db/src/schema/types.rs
@@ -26,6 +26,8 @@ impl AsRef<[u8]> for DbBytes {
 }
 
 pub type DbHash = DbBytes;
+pub type JmtValue = Option<Vec<u8>>;
+pub(crate) type StateKey = Vec<u8>;
 
 /// The on-disk format of a slot. Specifies the batches contained in the slot
 /// and the hash of the da block. TODO(@preston-evans98): add any additional data

--- a/db/sovereign-db/src/state_db.rs
+++ b/db/sovereign-db/src/state_db.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use jmt::{storage::TreeReader, KeyHash, Version};
+use jmt::{
+    storage::{TreeReader, TreeWriter},
+    KeyHash, Version,
+};
 use schemadb::DB;
 
 use crate::schema::tables::{JmtNodes, JmtValues, KeyHashToKey};
@@ -23,10 +26,22 @@ impl TreeReader for StateDB {
         key_hash: KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         if let Some(key) = self.db.get::<KeyHashToKey>(&key_hash.0)? {
-            return Ok(self
-                .db
-                .get::<JmtValues>(&(version, key))?
-                .map(|v| v.as_ref().to_vec()));
+            let mut iter = self.db.rev_iter::<JmtValues>()?;
+            // find the latest instance of the key whose version <= target
+            iter.seek_for_prev(&(&key, version))?;
+            let found = iter.next();
+            return match found {
+                Some(result) => {
+                    let ((found_key, found_version), value) = result?;
+                    if found_key == key {
+                        anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
+                        Ok(value.into())
+                    } else {
+                        Ok(None)
+                    }
+                }
+                None => Ok(None),
+            };
         }
         Ok(None)
     }
@@ -35,5 +50,24 @@ impl TreeReader for StateDB {
         &self,
     ) -> anyhow::Result<Option<(jmt::storage::NodeKey, jmt::storage::LeafNode)>> {
         todo!()
+    }
+}
+
+impl TreeWriter for StateDB {
+    fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> anyhow::Result<()> {
+        for (node_key, node) in node_batch.nodes() {
+            self.db.put::<JmtNodes>(node_key, node)?;
+        }
+
+        for ((version, key_hash), value) in node_batch.values() {
+            let key_preimage =
+                self.db
+                    .get::<KeyHashToKey>(&key_hash.0)?
+                    .ok_or(anyhow::format_err!(
+                        "Could not find preimage for key hash {key_hash:?}"
+                    ))?;
+            self.db.put::<JmtValues>(&(key_preimage, *version), value)?;
+        }
+        Ok(())
     }
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -19,4 +19,3 @@ proptest =  { workspace = true, optional = true }
 
 [features]
 fuzzing = ["proptest"]
-sync = []

--- a/sdk/src/node/db/slot.rs
+++ b/sdk/src/node/db/slot.rs
@@ -1,5 +1,5 @@
-use super::Result;
-use super::{errors::CodecError, ColumnFamilyName, KeyCodec, Schema, ValueCodec};
+use super::{errors::CodecError, ColumnFamilyName, Schema, ValueCodec};
+use super::{KeyDecoder, KeyEncoder, Result};
 use std::fmt::Debug;
 
 use crate::{serial::Decode, services::da::SlotData};
@@ -17,14 +17,19 @@ impl<T: Debug + Send + Sync + 'static + SlotData> Schema for SlotSchema<T> {
     const COLUMN_FAMILY_NAME: ColumnFamilyName = SLOT_CF_NAME;
 }
 
-impl<T: Debug + Send + Sync + 'static> KeyCodec<SlotSchema<T>> for SlotNumber
+impl<T: Debug + Send + Sync + 'static> KeyEncoder<SlotSchema<T>> for SlotNumber
 where
     T: SlotData,
 {
     fn encode_key(&self) -> super::Result<Vec<u8>> {
         Ok(self.to_be_bytes().to_vec())
     }
+}
 
+impl<T: Debug + Send + Sync + 'static> KeyDecoder<SlotSchema<T>> for SlotNumber
+where
+    T: SlotData,
+{
     fn decode_key(data: &[u8]) -> super::Result<Self> {
         if data.len() != 8 {
             return Err(CodecError::InvalidKeyLength {

--- a/sdk/src/node/db/slot_by_hash.rs
+++ b/sdk/src/node/db/slot_by_hash.rs
@@ -1,5 +1,5 @@
-use super::Result;
-use super::{ColumnFamilyName, KeyCodec, Schema, ValueCodec};
+use super::{ColumnFamilyName, KeyDecoder, Schema, ValueCodec};
+use super::{KeyEncoder, Result};
 use std::fmt::Debug;
 
 use crate::da::BlockHashTrait;
@@ -21,7 +21,7 @@ where
     const COLUMN_FAMILY_NAME: ColumnFamilyName = SLOT_BY_HASH_CF_NAME;
 }
 
-impl<K, V> KeyCodec<SlotByHashSchema<K, V>> for K
+impl<K, V> KeyEncoder<SlotByHashSchema<K, V>> for K
 where
     K: Debug + Send + Sync + 'static + BlockHashTrait,
     V: Debug + Send + Sync + 'static + SlotData,
@@ -29,7 +29,13 @@ where
     fn encode_key(&self) -> Result<Vec<u8>> {
         Ok(self.encode_to_vec())
     }
+}
 
+impl<K, V> KeyDecoder<SlotByHashSchema<K, V>> for K
+where
+    K: Debug + Send + Sync + 'static + BlockHashTrait,
+    V: Debug + Send + Sync + 'static + SlotData,
+{
     fn decode_key(mut data: &[u8]) -> Result<Self> {
         Ok(K::decode(&mut data)?)
     }

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -7,7 +7,15 @@ edition = "2021"
 # TODO remove this dependency once the  Decode/Encode traits are extracted to a separate crate.
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+sovereign-db = { workspace = true }
 sovereign-sdk = { workspace = true }
 first-read-last-write-cache = { workspace = true }
 jmt = { workspace = true }
 hex = { workspace = true}
+
+[dev-dependencies]
+sovereign-db = { workspace = true, features = ["temp"] }
+
+[features]
+default = []
+temp = ["sovereign-db/temp"]


### PR DESCRIPTION
- Change the schema for JMT values from "(version, key) -> Value" to "(key, version)->Value".
- Implement TreeReader for StateDB
- Split KeyCodec trait into two traits: KeyEncoder and KeyDecoder. This allows us to operate on borrowed keys during get and put operations.