### PR TITLE
Add support for `where` caluse in `#[derive(ModuleInfo)]`

### DIFF
--- a/sov-modules/sov-modules-macros/tests/module_info/mod_and_state.rs
+++ b/sov-modules/sov-modules-macros/tests/module_info/mod_and_state.rs
@@ -7,7 +7,10 @@ pub mod first_test_module {
     use super::*;
 
     #[derive(ModuleInfo)]
-    pub(crate) struct FirstTestStruct<C: Context> {
+    pub(crate) struct FirstTestStruct<C>
+    where
+        C: Context,
+    {
         #[state]
         pub state_in_first_struct_1: StateMap<C::PublicKey, u32, C::Storage>,
 


### PR DESCRIPTION
This PR fixes a bug in `#[derive(ModuleInfo)]`, before this change we couldn't use the where clause in the module definition. 