### PR TITLE
fix rust toolchain for sov workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,24 +10,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustc
-
       - uses: Swatinem/rust-cache@v2.2.0
-      - name: Run cargo build
+      - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+  test:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: Swatinem/rust-cache@v2.2.0
+        - name: Run cargo test
+          uses: actions-rs/cargo@v1
+          with:
+            command: test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-02-25"
+components = [ "rustfmt" ]
+profile = "minimal"


### PR DESCRIPTION
This PR introduces the following changes:
1.  Pins rust toolchain to `nightly-2023-02-25`
2. Changes `cargo build` to faster `cargo check` (`cargo test` already runs `cargo build` so we don't have to run it 2x)
3. `cargo check & cargo test` run as separate job (in parallel)