### PR TITLE
Implementation of ValueReader for StateDb

### DIFF
--- a/db/sovereign-db/src/state_db.rs
+++ b/db/sovereign-db/src/state_db.rs
@@ -8,7 +8,10 @@ use schemadb::DB;
 
 use crate::{
     rocks_db_config::gen_rocksdb_options,
-    schema::tables::{JmtNodes, JmtValues, KeyHashToKey, STATE_TABLES},
+    schema::{
+        tables::{JmtNodes, JmtValues, KeyHashToKey, STATE_TABLES},
+        types::StateKey,
+    },
 };
 
 #[derive(Clone)]
@@ -39,6 +42,29 @@ impl StateDB {
     pub fn put_preimage(&self, key_hash: KeyHash, key: &Vec<u8>) -> Result<(), anyhow::Error> {
         self.db.put::<KeyHashToKey>(&key_hash.0, key)
     }
+
+    pub fn get_value_option_by_key(
+        &self,
+        version: Version,
+        key: &StateKey,
+    ) -> anyhow::Result<Option<jmt::OwnedValue>> {
+        let mut iter = self.db.iter::<JmtValues>()?;
+        // find the latest instance of the key whose version <= target
+        iter.seek_for_prev(&(&key, version))?;
+        let found = iter.next();
+        match found {
+            Some(result) => {
+                let ((found_key, found_version), value) = result?;
+                if &found_key == key {
+                    anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
+                    Ok(value)
+                } else {
+                    Ok(None)
+                }
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 impl TreeReader for StateDB {
@@ -55,24 +81,10 @@ impl TreeReader for StateDB {
         key_hash: KeyHash,
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         if let Some(key) = self.db.get::<KeyHashToKey>(&key_hash.0)? {
-            let mut iter = self.db.iter::<JmtValues>()?;
-            // find the latest instance of the key whose version <= target
-            iter.seek_for_prev(&(&key, version))?;
-            let found = iter.next();
-            return match found {
-                Some(result) => {
-                    let ((found_key, found_version), value) = result?;
-                    if found_key == key {
-                        anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
-                        Ok(value.into())
-                    } else {
-                        Ok(None)
-                    }
-                }
-                None => Ok(None),
-            };
+            self.get_value_option_by_key(version, &key)
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 
     fn get_rightmost_leaf(
@@ -123,6 +135,9 @@ mod state_db_tests {
         db.write_node_batch(&batch).unwrap();
 
         let found = db.get_value(0, key_hash).unwrap();
-        assert_eq!(found, value)
+        assert_eq!(found, value);
+
+        let found = db.get_value_option_by_key(0, &key).unwrap().unwrap();
+        assert_eq!(found, value);
     }
 }

--- a/sov-modules/sov-modules-api/src/dispatch.rs
+++ b/sov-modules/sov-modules-api/src/dispatch.rs
@@ -3,12 +3,9 @@ use crate::{CallResponse, Context, Error, QueryResponse, Spec};
 /// Methods from this trait should be called only once during the rollup deployment.
 pub trait Genesis {
     type Context: Context;
-    type Config;
 
     /// Initializes the state of the rollup.
-    fn genesis(
-        config: Self::Config,
-    ) -> Result<<<Self as Genesis>::Context as Spec>::Storage, Error>;
+    fn genesis(storage: <<Self as Genesis>::Context as Spec>::Storage) -> Result<(), Error>;
 }
 
 /// A trait that needs to be implemented for any call message.

--- a/sov-modules/sov-modules-impl/example-election/Cargo.toml
+++ b/sov-modules/sov-modules-impl/example-election/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dev-dependencies]
 sov-modules-api = { workspace = true ,  features = ["mocks"]}
-sovereign-db = { workspace = true }
+sov-state = { workspace = true, features = ["temp"] }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/sov-modules/sov-modules-impl/example-election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-election/src/tests.rs
@@ -4,6 +4,7 @@ use super::{
     types::Candidate,
     Election,
 };
+
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey, ZkMockContext},
     Context, Module, ModuleInfo,
@@ -12,10 +13,10 @@ use sov_state::{JmtStorage, ZkStorage};
 
 #[test]
 fn test_election() {
-    let storage = JmtStorage::temporary();
-    test_module::<MockContext>(storage.clone());
+    let native_storage = JmtStorage::temporary();
+    test_module::<MockContext>(native_storage.clone());
 
-    let zk_storage = ZkStorage::new(storage.get_first_reads());
+    let zk_storage = ZkStorage::new(native_storage.get_first_reads());
     test_module::<ZkMockContext>(zk_storage);
 }
 

--- a/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
@@ -5,8 +5,7 @@ use sov_modules_api::mocks::ZkMockContext;
 use sov_modules_api::mocks::{MockContext, MockPublicKey};
 use sov_modules_api::Context;
 use sov_modules_api::{Module, ModuleInfo};
-use sov_state::JmtStorage;
-use sov_state::ZkStorage;
+use sov_state::{JmtStorage, ZkStorage};
 use sovereign_sdk::stf::Event;
 
 #[test]
@@ -16,18 +15,14 @@ fn test_value_setter() {
 
     // Test Native-Context
     {
-        let context = MockContext {
-            sender: sender.clone(),
-        };
-
+        let context = MockContext::new(sender.clone());
         test_value_setter_helper(context, storage.clone());
     }
 
     // Test Zk-Context
     {
-        let zk_context = ZkMockContext { sender };
-
         let zk_storage = ZkStorage::new(storage.get_first_reads());
+        let zk_context = ZkMockContext::new(sender);
         test_value_setter_helper(zk_context, zk_storage);
     }
 }
@@ -69,18 +64,14 @@ fn test_err_on_sender_is_not_admin() {
 
     // Test Native-Context
     {
-        let context = MockContext {
-            sender: sender.clone(),
-        };
-
+        let context = MockContext::new(sender.clone());
         test_err_on_sender_is_not_admin_helper(context, storage.clone());
     }
 
     // Test Zk-Context
     {
-        let zk_context = ZkMockContext { sender };
-
         let zk_storage = ZkStorage::new(storage.get_first_reads());
+        let zk_context = ZkMockContext::new(sender);
         test_err_on_sender_is_not_admin_helper(zk_context, zk_storage);
     }
 }

--- a/sov-modules/sov-modules-impl/integration-tests/Cargo.toml
+++ b/sov-modules/sov-modules-impl/integration-tests/Cargo.toml
@@ -10,7 +10,6 @@ sov-modules-api = { workspace = true ,  features = ["mocks"]}
 sov-modules-macros = { workspace = true }
 example-election = {path = "../example-election" }
 example-value-setter = {path = "../example-value-setter" }
-sov-state = { workspace = true }
+sov-state = { workspace = true, features = ["temp"] }
 borsh = { workspace = true, features = ["rc"]}
 sovereign-sdk = { workspace = true}
-sovereign-db = { workspace = true, features = ["temp"]}

--- a/sov-modules/sov-modules-impl/integration-tests/tests/demo/basic_runtime.rs
+++ b/sov-modules/sov-modules-impl/integration-tests/tests/demo/basic_runtime.rs
@@ -8,8 +8,7 @@ use sov_modules_api::{
     CallResponse, Context, DispatchCall, DispatchQuery, Error, Genesis, Module,
 };
 use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
-use sov_state::{CacheLog, ValueReader};
-use sovereign_db::state_db::StateDB;
+use sov_state::{CacheLog, JmtStorage, ValueReader};
 
 /// dispatch_tx is a high level interface used by the sdk.
 /// Transaction signature must be checked outside of this function.
@@ -70,13 +69,15 @@ pub struct Runtime<C: Context> {
 
 fn run_example() {
     type C = MockContext;
+
     let sender = MockPublicKey::try_from("admin").unwrap();
-    let admin_context = C::new(sender);
-    let temp_db = StateDB::temporary();
+    let storage = JmtStorage::temporary();
     type RT = Runtime<C>;
 
     // Initialize the rollup: Call genesis on the Runtime
-    let storage = RT::genesis(temp_db).unwrap();
+    RT::genesis(storage.clone()).unwrap();
+
+    let admin_context = C::new(sender);
 
     // Election module
     // Send candidates

--- a/sov-modules/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/sov-modules/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -6,7 +6,7 @@ use sov_modules_api::{
     Context, Genesis, Module,
 };
 use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
-use sovereign_db::state_db::StateDB;
+use sov_state::JmtStorage;
 
 #[derive(Genesis, DispatchCall, DispatchQuery, MessageCodec)]
 struct Runtime<C: Context> {
@@ -18,12 +18,9 @@ fn main() {
     use sov_modules_api::{DispatchCall, DispatchQuery};
     type RT = Runtime<MockContext>;
 
-    let db = StateDB::temporary();
-    let storage = RT::genesis(db).unwrap();
-
-    let context = MockContext {
-        sender: MockPublicKey::new(vec![]),
-    };
+    let storage = JmtStorage::temporary();
+    RT::genesis(storage.clone()).unwrap();
+    let context = MockContext::new(MockPublicKey::new(vec![]));
 
     let value = 11;
     {

--- a/sov-modules/sov-modules-macros/tests/dispatch/derive_genesis.rs
+++ b/sov-modules/sov-modules-macros/tests/dispatch/derive_genesis.rs
@@ -3,7 +3,7 @@ mod modules;
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::{mocks::MockContext, Context, Module};
 use sov_modules_macros::{DispatchQuery, Genesis};
-use sovereign_db::state_db::StateDB;
+use sov_state::JmtStorage;
 
 // Debugging hint: To expand the macro in tests run: `cargo expand --test tests`
 #[derive(Genesis, DispatchQuery)]
@@ -19,8 +19,8 @@ fn main() {
     use sov_modules_api::{DispatchQuery, Genesis};
 
     type C = MockContext;
-    let db = StateDB::temporary();
-    let storage = Runtime::<C>::genesis(db).unwrap();
+    let storage = JmtStorage::temporary();
+    Runtime::<C>::genesis(storage.clone()).unwrap();
 
     {
         let message = RuntimeQuery::<C>::first(());

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -9,6 +9,7 @@ impl ValueReader for StateDB {
     fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
         match self.get_value_option_by_key(0, key.as_ref()) {
             Ok(value) => value.map(StorageValue::new_from_bytes),
+            // It is ok to panic here, we assume the db is available and consistent.
             Err(e) => panic!("Unable to read value from db: {e}"),
         }
     }

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -1,73 +1,30 @@
 use crate::{
-    internal_cache::{StorageInternalCache, ValueReader},
-    storage::{StorageKey, StorageValue},
-    Storage,
+    internal_cache::ValueReader,
+    storage::{GenericStorage, StorageKey, StorageValue},
 };
 use first_read_last_write_cache::cache::{CacheLog, FirstReads};
+use sovereign_db::state_db::StateDB;
 
-pub type JmtDb = sovereign_db::state_db::StateDB;
-
-impl ValueReader for JmtDb {
-    fn read_value(&self, _key: StorageKey) -> Option<StorageValue> {
-        None
+impl ValueReader for StateDB {
+    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
+        match self.get_value_option_by_key(0, key.as_ref()) {
+            Ok(value) => value.map(StorageValue::new_from_bytes),
+            Err(e) => panic!("Unable to read value from db: {e}"),
+        }
     }
 }
 
-/// Storage backed by JmtDb.
-#[derive(Clone)]
-pub struct JmtStorage {
-    pub(crate) db: JmtDb,
-    // Caches first read and last write for a particular key.
-    pub(crate) internal_cache: StorageInternalCache,
-}
+pub type JmtStorage = GenericStorage<StateDB>;
 
 impl JmtStorage {
-    /// Creates a new JmtStorage.
-    pub fn new(jmt: JmtDb) -> Self {
-        Self {
-            internal_cache: StorageInternalCache::default(),
-            db: jmt,
-        }
-    }
-
     #[cfg(any(test, feature = "temp"))]
     pub fn temporary() -> Self {
-        Self {
-            internal_cache: StorageInternalCache::default(),
-            db: JmtDb::temporary(),
-        }
+        Self::new(StateDB::temporary())
     }
 
     /// Gets the first reads from the JmtStorage.
     pub fn get_first_reads(&self) -> FirstReads {
         let cache: &CacheLog = &self.internal_cache.cache.borrow();
         cache.get_first_reads()
-    }
-}
-
-impl Storage for JmtStorage {
-    /// Instead of a config object, we just pass in the
-    /// db instance directly for now.
-    //  TODO: decide whether to use an actual config, or
-    //  rename this type
-    type Config = JmtDb;
-
-    fn new(config: Self::Config) -> Self {
-        Self {
-            db: config,
-            internal_cache: Default::default(),
-        }
-    }
-
-    fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.internal_cache.get_or_fetch(key, &self.db)
-    }
-
-    fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.internal_cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: StorageKey) {
-        self.internal_cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/storage.rs
+++ b/sov-modules/sov-state/src/storage.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, sync::Arc};
 
-use crate::{utils::AlignedVec, Prefix};
+use crate::{internal_cache::StorageInternalCache, utils::AlignedVec, Prefix, ValueReader};
 use first_read_last_write_cache::{CacheKey, CacheValue};
 use hex;
 use sovereign_sdk::serial::Encode;
@@ -80,13 +80,16 @@ impl StorageValue {
             value: cache_value.value,
         }
     }
+
+    pub fn new_from_bytes(value: Vec<u8>) -> Self {
+        Self {
+            value: Arc::new(value),
+        }
+    }
 }
 
 // An interface for storing and retrieving values in the storage.
 pub trait Storage {
-    type Config;
-    /// Creates a new storage instance with the provided config.
-    fn new(config: Self::Config) -> Self;
     // Returns the value corresponding to the key or None if key is absent.
     fn get(&self, key: StorageKey) -> Option<StorageValue>;
 
@@ -114,5 +117,34 @@ impl From<&'static str> for StorageValue {
         Self {
             value: Arc::new(value.as_bytes().to_vec()),
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct GenericStorage<VR: ValueReader> {
+    value_reader: VR,
+    pub(crate) internal_cache: StorageInternalCache,
+}
+
+impl<VR: ValueReader> GenericStorage<VR> {
+    pub fn new(value_reader: VR) -> Self {
+        Self {
+            value_reader,
+            internal_cache: StorageInternalCache::default(),
+        }
+    }
+}
+
+impl<VR: ValueReader> Storage for GenericStorage<VR> {
+    fn get(&self, key: StorageKey) -> Option<StorageValue> {
+        self.internal_cache.get_or_fetch(key, &self.value_reader)
+    }
+
+    fn set(&mut self, key: StorageKey, value: StorageValue) {
+        self.internal_cache.set(key, value)
+    }
+
+    fn delete(&mut self, key: StorageKey) {
+        self.internal_cache.delete(key)
     }
 }

--- a/sov-modules/sov-state/src/zk_storage.rs
+++ b/sov-modules/sov-state/src/zk_storage.rs
@@ -1,9 +1,8 @@
 use first_read_last_write_cache::cache::{self, FirstReads};
 
 use crate::{
-    internal_cache::{StorageInternalCache, ValueReader},
-    storage::{StorageKey, StorageValue},
-    Storage,
+    internal_cache::ValueReader,
+    storage::{GenericStorage, StorageKey, StorageValue},
 };
 
 // Implementation of `ValueReader` trait for the zk-context. FirstReads is backed by a HashMap internally,
@@ -21,37 +20,4 @@ impl ValueReader for FirstReads {
     }
 }
 
-#[derive(Default, Clone)]
-pub struct ZkStorage {
-    pub(crate) first_reads: FirstReads,
-    // Caches first read and last write for a particular key.
-    pub(crate) internal_cache: StorageInternalCache,
-}
-impl ZkStorage {
-    pub fn new(first_reads: FirstReads) -> Self {
-        Self {
-            internal_cache: StorageInternalCache::default(),
-            first_reads,
-        }
-    }
-}
-
-impl Storage for ZkStorage {
-    type Config = ();
-
-    fn new(_config: Self::Config) -> Self {
-        Default::default()
-    }
-
-    fn get(&self, key: StorageKey) -> Option<StorageValue> {
-        self.internal_cache.get_or_fetch(key, &self.first_reads)
-    }
-
-    fn set(&mut self, key: StorageKey, value: StorageValue) {
-        self.internal_cache.set(key, value)
-    }
-
-    fn delete(&mut self, key: StorageKey) {
-        self.internal_cache.delete(key)
-    }
-}
+pub type ZkStorage = GenericStorage<FirstReads>;


### PR DESCRIPTION
This PR introduces the following changes:
1. Adds `get_value_option_by_key ` method in `StateDB`
2. Implements `ValueReader` for `StateDB`
3. Updates the `Genesis` trait, now the `genesis` method accepts `Storage` instead of `Config`. 
This change decoupled  storage creation  from the module system and enabled point 4. and 5. 
5. Removes `Config` associated type from the `Storage` trait.
6. Introduces `GenericStorage` struct which is shared by `JmtStorage` and `ZkStorage` (we used to have it)




