### PR TITLE
fix clippy warnings in the workspace

### DIFF
--- a/db/sovereign-db/src/schema/tables.rs
+++ b/db/sovereign-db/src/schema/tables.rs
@@ -33,7 +33,7 @@ use sovereign_sdk::{
     stf::{EventKey, EventValue},
 };
 
-pub const STATE_TABLES: &[&'static str] = &[
+pub const STATE_TABLES: &[&str] = &[
     KeyHashToKey::table_name(),
     JmtValues::table_name(),
     JmtNodes::table_name(),

--- a/db/sovereign-db/src/state_db.rs
+++ b/db/sovereign-db/src/state_db.rs
@@ -21,7 +21,7 @@ impl StateDB {
         let inner = DB::open(
             path,
             "state-db",
-            STATE_TABLES.iter().map(|x| *x),
+            STATE_TABLES.iter().copied(),
             &gen_rocksdb_options(&Default::default(), false),
         )?;
         Ok(Self {
@@ -64,7 +64,7 @@ impl TreeReader for StateDB {
                     let ((found_key, found_version), value) = result?;
                     if found_key == key {
                         anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
-                        Ok(value.into())
+                        Ok(value)
                     } else {
                         Ok(None)
                     }

--- a/sdk/src/state_machine/core/run.rs
+++ b/sdk/src/state_machine/core/run.rs
@@ -80,7 +80,7 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Rollup<DaLayer, App> {
                 let commitment = proof
                     .code_commitment
                     .clone()
-                    .unwrap_or_else(|| env::read_unchecked());
+                    .unwrap_or_else(env::read_unchecked);
                 let prev_header = proof.verify(&commitment)?;
                 (prev_header, Some(commitment))
             }
@@ -108,7 +108,7 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Rollup<DaLayer, App> {
             let mut data = tx.data();
             let len = data.remaining();
             let data = data.copy_to_bytes(len);
-            match ConsensusMessage::decode_from_slice(&mut &data[..]).unwrap() {
+            match ConsensusMessage::decode_from_slice(&data[..]).unwrap() {
                 ConsensusMessage::Batch(batch) => {
                     if current_sequencers.allows(tx.sender()) {
                         match self.app.apply_batch(

--- a/sdk/src/state_machine/da.rs
+++ b/sdk/src/state_machine/da.rs
@@ -42,7 +42,7 @@ pub trait DaLayerTrait {
     fn verify_relevant_tx_list(
         &self,
         blockheader: &Self::BlockHeader,
-        txs: &Vec<Self::BlobTransaction>,
+        txs: &[Self::BlobTransaction],
         inclusion_proof: Self::InclusionMultiProof,
         completeness_proof: Self::CompletenessProof,
     ) -> Result<(), Self::Error>;

--- a/sdk/src/state_machine/stf.rs
+++ b/sdk/src/state_machine/stf.rs
@@ -117,12 +117,12 @@ impl<'de, P: DecodeBorrowed<'de>, B: DecodeBorrowed<'de>> DecodeBorrowed<'de>
                 .ok_or(ConsensusMessageDecodeError::NoTag)?
             {
                 0 => Self::Batch(
-                    B::decode_from_slice(&mut &target[1..])
-                        .map_err(|e| ConsensusMessageDecodeError::Batch(e))?,
+                    B::decode_from_slice(&target[1..])
+                        .map_err(ConsensusMessageDecodeError::Batch)?,
                 ),
                 1 => Self::Proof(
-                    P::decode_from_slice(&mut &target[1..])
-                        .map_err(|e| ConsensusMessageDecodeError::Proof(e))?,
+                    P::decode_from_slice(&target[1..])
+                        .map_err(ConsensusMessageDecodeError::Proof)?,
                 ),
                 _ => Err(ConsensusMessageDecodeError::InvalidTag {
                     max_allowed: 1,


### PR DESCRIPTION
Fixes for warnings discovered by clippy: `cargo clippy -- -D warnings` 
Needed for  #76