### PR TITLE
`basic_runtime` refactoring

### DIFF
--- a/sov-modules/sov-modules-impl/integration-tests/tests/demo/basic_runtime.rs
+++ b/sov-modules/sov-modules-impl/integration-tests/tests/demo/basic_runtime.rs
@@ -2,14 +2,13 @@
 //! This `Runtime` serves as a basic example of how to wire up module system and trigger the rollup logic.
 
 #![allow(dead_code)]
-
-use example_election::Candidate;
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey},
     CallResponse, Context, DispatchCall, DispatchQuery, Error, Genesis, Module,
 };
 use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 use sov_state::{CacheLog, JmtStorage, Storage, ValueReader};
+use std::str;
 
 /// dispatch_tx is a high level interface used by the sdk.
 /// Transaction signature must be checked outside of this function.
@@ -68,162 +67,96 @@ pub struct Runtime<C: Context> {
     value_setter: example_value_setter::ValueSetter<C>,
 }
 
-fn call_election_module<C: Context<PublicKey = MockPublicKey>>(storage: &C::Storage) {
-    let sender = MockPublicKey::try_from("admin").unwrap();
-    let admin_context = C::new(sender);
-
-    // Election module
-    // Send candidates
-    {
-        let set_candidates_message = example_election::call::CallMessage::<C>::SetCandidates {
-            names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
-        };
-
-        let serialized_message = Runtime::<C>::encode_election_call(set_candidates_message);
-        let module = Runtime::<C>::decode_call(&serialized_message).unwrap();
-        let result = module.dispatch_call(storage.clone(), &admin_context);
-        assert!(result.is_ok())
-    }
-
-    let voters = vec![
-        MockPublicKey::try_from("voter_1").unwrap(),
-        MockPublicKey::try_from("voter_2").unwrap(),
-        MockPublicKey::try_from("voter_3").unwrap(),
-    ];
-
-    // Add voters
-    {
-        for voter in voters.iter() {
-            let add_voter_message =
-                example_election::call::CallMessage::<C>::AddVoter(voter.clone());
-
-            let serialized_message = Runtime::<C>::encode_election_call(add_voter_message);
-            let module = Runtime::<C>::decode_call(&serialized_message).unwrap();
-
-            let result = module.dispatch_call(storage.clone(), &admin_context);
-
-            assert!(result.is_ok())
-        }
-    }
-
-    // Vote
-    {
-        for voter in voters {
-            let voter_context = C::new(voter);
-            let vote_message = example_election::call::CallMessage::<C>::Vote(1);
-
-            let serialized_message = Runtime::<C>::encode_election_call(vote_message);
-            let module = Runtime::<C>::decode_call(&serialized_message).unwrap();
-
-            let result = module.dispatch_call(storage.clone(), &voter_context);
-            assert!(result.is_ok())
-        }
-    }
-
-    // Freeze
-    {
-        let freeze_message = example_election::call::CallMessage::<C>::FreezeElection;
-
-        let serialized_message = Runtime::<C>::encode_election_call(freeze_message);
-        let module = Runtime::<C>::decode_call(&serialized_message).unwrap();
-
-        let result = module.dispatch_call(storage.clone(), &admin_context);
-        assert!(result.is_ok())
-    }
+struct Message {
+    sender: MockPublicKey,
+    data: Vec<u8>,
 }
 
-fn call_value_setter_module<C: Context<PublicKey = MockPublicKey>>(storage: &C::Storage) {
-    let sender = MockPublicKey::try_from("admin").unwrap();
+fn execute<C: Context<PublicKey = MockPublicKey>>(storage: &C::Storage, message: Message) {
+    let module = Runtime::<C>::decode_call(&message.data).unwrap();
+    let context = Context::new(message.sender);
+    let result = module.dispatch_call(storage.clone(), &context);
 
-    let admin_context = C::new(sender);
-
-    // Set new value
-    let new_value = 99;
-    {
-        let set_value_msg = example_value_setter::call::CallMessage::DoSetValue(
-            example_value_setter::call::SetValue { new_value },
-        );
-
-        let serialized_message = Runtime::<C>::encode_value_setter_call(set_value_msg);
-        let module = Runtime::<C>::decode_call(&serialized_message).unwrap();
-        let result = module.dispatch_call(storage.clone(), &admin_context);
-
-        assert!(result.is_ok())
-    }
+    assert!(result.is_ok())
 }
 
-fn query_election_returns_correct_result(storage: JmtStorage) -> bool {
-    let serialized_message = QueryGenerator::generate_query_election_message();
-    let module = Runtime::<MockContext>::decode_query(&serialized_message).unwrap();
-
+fn check_query(query: Vec<u8>, expected_response: &str, storage: JmtStorage) {
+    let module = Runtime::<MockContext>::decode_query(&query).unwrap();
     let query_response = module.dispatch_query(storage);
 
-    let response: example_election::query::Response =
-        serde_json::from_slice(&query_response.response).unwrap();
-
-    response
-        == example_election::query::Response::Result(Some(Candidate {
-            name: "candidate_2".to_owned(),
-            count: 3,
-        }))
+    let response = str::from_utf8(&query_response.response).unwrap();
+    assert_eq!(response, expected_response)
 }
 
-fn query_value_setter_returns_correct_result(storage: JmtStorage) -> bool {
-    let serialized_message = QueryGenerator::generate_query_value_setter_message();
-    let module = Runtime::<MockContext>::decode_query(&serialized_message).unwrap();
-
-    let new_value = 99;
-    let query_response = module.dispatch_query(storage);
-    let response: example_value_setter::query::Response =
-        serde_json::from_slice(&query_response.response).unwrap();
-
-    response
-        == example_value_setter::query::Response {
-            value: Some(new_value),
-        }
-}
-
-fn check_query(storage: JmtStorage) -> bool {
-    query_election_returns_correct_result(storage.clone())
-        && query_value_setter_returns_correct_result(storage)
+fn simulate_da() -> Vec<Message> {
+    let mut messages = Vec::default();
+    messages.extend(CallGenerator::election_call_messages());
+    messages.extend(CallGenerator::value_setter_call_messages());
+    messages
 }
 
 use serial_test::serial;
+
 #[test]
 #[serial]
 fn test_demo_values_in_cache() {
     type C = MockContext;
 
-    let storage = JmtStorage::temporary();
-    // Initialize the rollup: Call genesis on the Runtime
+    let path = schemadb::temppath::TempPath::new();
+
+    let storage = JmtStorage::with_path(&path).unwrap();
     Runtime::<C>::genesis(storage.clone()).unwrap();
 
-    call_election_module::<C>(&storage);
-    call_value_setter_module::<C>(&storage);
-    // We didn't save anything in the db, but they exist in the Storage cache.
-    assert!(check_query(storage))
+    for message in simulate_da() {
+        execute::<C>(&storage, message);
+    }
+
+    check_query(
+        QueryGenerator::generate_query_election_message(),
+        r#"{"Result":{"name":"candidate_2","count":3}}"#,
+        storage.clone(),
+    );
+
+    check_query(
+        QueryGenerator::generate_query_value_setter_message(),
+        r#"{"value":99}"#,
+        storage,
+    );
 }
 
 #[test]
 #[serial]
 fn test_demo_values_in_db() {
     type C = MockContext;
+
     let path = schemadb::temppath::TempPath::new();
+
     {
         let mut storage = JmtStorage::with_path(&path).unwrap();
-
         Runtime::<C>::genesis(storage.clone()).unwrap();
 
-        call_election_module::<C>(&storage);
-        call_value_setter_module::<C>(&storage);
-        // Save storage values in the db.
+        for message in simulate_da() {
+            execute::<C>(&storage, message);
+        }
+
         storage.merge();
         storage.finalize();
     }
+
     // Generate new storage instance after dumping data to the db.
     {
         let storage = JmtStorage::with_path(path).unwrap();
-        assert!(check_query(storage))
+        check_query(
+            QueryGenerator::generate_query_election_message(),
+            r#"{"Result":{"name":"candidate_2","count":3}}"#,
+            storage.clone(),
+        );
+
+        check_query(
+            QueryGenerator::generate_query_value_setter_message(),
+            r#"{"value":99}"#,
+            storage,
+        );
     }
 }
 
@@ -231,23 +164,92 @@ fn test_demo_values_in_db() {
 #[serial]
 fn test_demo_values_not_in_db() {
     type C = MockContext;
+
     let path = schemadb::temppath::TempPath::new();
+
     {
         let storage = JmtStorage::with_path(&path).unwrap();
-
         Runtime::<C>::genesis(storage.clone()).unwrap();
-
-        call_election_module::<C>(&storage);
-        call_value_setter_module::<C>(&storage);
-        // Don't save anything in the db.
+        for message in simulate_da() {
+            execute::<C>(&storage, message);
+        }
     }
-    // The DB lookup fails because we generated fresh storage, but we didn't save values in the db before.
+
+    // Generate new storage instance after dumping data to the db.
     {
         let storage = JmtStorage::with_path(path).unwrap();
-        assert!(!check_query(storage))
+
+        check_query(
+            QueryGenerator::generate_query_election_message(),
+            r#"{"Err":"Election is not frozen"}"#,
+            storage.clone(),
+        );
+
+        check_query(
+            QueryGenerator::generate_query_value_setter_message(),
+            r#"{"value":null}"#,
+            storage,
+        );
     }
 }
 
+// Test helpers
+struct CallGenerator {}
+
+impl CallGenerator {
+    fn election_call_messages() -> Vec<Message> {
+        let mut messages = Vec::default();
+
+        let admin = MockPublicKey::try_from("admin").unwrap();
+
+        let set_candidates_message =
+            example_election::call::CallMessage::<MockContext>::SetCandidates {
+                names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
+            };
+
+        messages.push((admin.clone(), set_candidates_message));
+
+        let voters = vec![
+            MockPublicKey::try_from("voter_1").unwrap(),
+            MockPublicKey::try_from("voter_2").unwrap(),
+            MockPublicKey::try_from("voter_3").unwrap(),
+        ];
+
+        for voter in voters {
+            let add_voter_message =
+                example_election::call::CallMessage::<MockContext>::AddVoter(voter.clone());
+
+            messages.push((admin.clone(), add_voter_message));
+
+            let vote_message = example_election::call::CallMessage::<MockContext>::Vote(1);
+            messages.push((voter, vote_message));
+        }
+
+        let freeze_message = example_election::call::CallMessage::<MockContext>::FreezeElection;
+        messages.push((admin, freeze_message));
+
+        messages
+            .into_iter()
+            .map(|(sender, m)| Message {
+                sender,
+                data: Runtime::<MockContext>::encode_election_call(m),
+            })
+            .collect()
+    }
+
+    fn value_setter_call_messages() -> Vec<Message> {
+        let admin = MockPublicKey::try_from("admin").unwrap();
+        let new_value = 99;
+        let set_value_msg = example_value_setter::call::CallMessage::DoSetValue(
+            example_value_setter::call::SetValue { new_value },
+        );
+
+        vec![Message {
+            sender: admin,
+            data: Runtime::<MockContext>::encode_value_setter_call(set_value_msg),
+        }]
+    }
+}
 struct QueryGenerator {}
 
 impl QueryGenerator {


### PR DESCRIPTION
This PR introduces the following changes:
1. Separates message creation from execution (see the `simulate_da()` function)
2. Introduces the `execute` function, which executes a single message 

These changes simplify the demo and structure the code closer to how it's going to be used with the `sovereign-sdk`