### PR TITLE
Update `test_value_absent_in_zk_storage`

### DIFF
--- a/sov-modules/sov-modules-impl/example-election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-election/src/tests.rs
@@ -9,12 +9,14 @@ use sov_modules_api::{
     mocks::{MockContext, MockPublicKey, ZkMockContext},
     Context, Module, ModuleInfo,
 };
-use sov_state::{JmtStorage, ZkStorage};
+use sov_state::{JmtStorage, Storage, ZkStorage};
 
 #[test]
 fn test_election() {
-    let native_storage = JmtStorage::temporary();
+    let mut native_storage = JmtStorage::temporary();
     test_module::<MockContext>(native_storage.clone());
+
+    native_storage.merge();
 
     let zk_storage = ZkStorage::new(native_storage.get_first_reads());
     test_module::<ZkMockContext>(zk_storage);

--- a/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
@@ -5,20 +5,20 @@ use sov_modules_api::mocks::ZkMockContext;
 use sov_modules_api::mocks::{MockContext, MockPublicKey};
 use sov_modules_api::Context;
 use sov_modules_api::{Module, ModuleInfo};
-use sov_state::{JmtStorage, ZkStorage};
+use sov_state::{JmtStorage, Storage, ZkStorage};
 use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
     let sender = MockPublicKey::try_from("admin").unwrap();
-    let storage = JmtStorage::temporary();
+    let mut storage = JmtStorage::temporary();
 
     // Test Native-Context
     {
         let context = MockContext::new(sender.clone());
         test_value_setter_helper(context, storage.clone());
     }
-
+    storage.merge();
     // Test Zk-Context
     {
         let zk_storage = ZkStorage::new(storage.get_first_reads());
@@ -60,13 +60,14 @@ fn test_value_setter_helper<C: Context>(context: C, storage: C::Storage) {
 #[test]
 fn test_err_on_sender_is_not_admin() {
     let sender = MockPublicKey::try_from("not_admin").unwrap();
-    let storage = JmtStorage::temporary();
+    let mut storage = JmtStorage::temporary();
 
     // Test Native-Context
     {
         let context = MockContext::new(sender.clone());
         test_err_on_sender_is_not_admin_helper(context, storage.clone());
     }
+    storage.merge();
 
     // Test Zk-Context
     {

--- a/sov-modules/sov-modules-impl/integration-tests/tests/nested_modules_tests.rs
+++ b/sov-modules/sov-modules-impl/integration-tests/tests/nested_modules_tests.rs
@@ -67,13 +67,14 @@ mod module_c {
 
 #[test]
 fn nested_module_call_test() {
-    let native_storage = JmtStorage::temporary();
+    let mut native_storage = JmtStorage::temporary();
 
     // Test the `native` execution.
     {
         execute_module_logic::<MockContext>(native_storage.clone());
         test_state_update::<MockContext>(native_storage.clone());
     }
+    native_storage.merge();
 
     // Test the `zk` execution.
     {

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -15,6 +15,7 @@ hex = { workspace = true}
 
 [dev-dependencies]
 sovereign-db = { workspace = true, features = ["temp"] }
+schemadb = { workspace = true, features = ["temppath"] }
 
 [features]
 default = []

--- a/sov-modules/sov-state/src/jmt_storage.rs
+++ b/sov-modules/sov-state/src/jmt_storage.rs
@@ -51,7 +51,7 @@ impl JmtStorage {
 
     /// Gets the first reads from the JmtStorage.
     pub fn get_first_reads(&self) -> FirstReads {
-        self.tx_cache.borrow().get_first_reads()
+        self.batch_cache.borrow().get_first_reads()
     }
 }
 

--- a/sov-modules/sov-state/src/storage_test.rs
+++ b/sov-modules/sov-state/src/storage_test.rs
@@ -1,30 +1,33 @@
-use first_read_last_write_cache::cache::FirstReads;
-use std::collections::HashMap;
-
 use crate::{
     storage::{StorageKey, StorageValue},
-    Storage, ZkStorage,
+    JmtStorage, Storage, ZkStorage,
 };
 
 #[test]
 fn test_value_absent_in_zk_storage() {
     let key = StorageKey::from("key");
-    let value = Some(StorageValue::from("value"));
+    let value = StorageValue::from("value");
 
-    // TODO: For now we crate the FirstReads manually. Once we have
-    // JmtDB ready, we should update the test to use JmtStorage instead.
-    let reads = make_reads(key.clone(), value.clone());
+    let path = schemadb::temppath::TempPath::new();
+    {
+        let mut storage = JmtStorage::with_path(&path).unwrap();
+        storage.set(key.clone(), value.clone());
+        storage.merge();
+        storage.finalize();
+    }
 
-    // Here we crate a new ZkStorage with an empty inner cache.
-    let storage = ZkStorage::new(reads);
-    // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
-    // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
-    let retrieved_value = storage.get(key);
-    assert_eq!(value, retrieved_value);
-}
+    {
+        let mut storage = JmtStorage::with_path(&path).unwrap();
+        storage.get(key.clone());
+        storage.merge();
 
-fn make_reads(key: StorageKey, value: Option<StorageValue>) -> FirstReads {
-    let mut reads = HashMap::default();
-    reads.insert(key.as_cache_key(), value.map(|v| v.as_cache_value()));
-    FirstReads::new(reads)
+        let reads = storage.get_first_reads();
+
+        // Here we crate a new ZkStorage with an empty inner cache.
+        let storage = ZkStorage::new(reads);
+        // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
+        // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
+        let retrieved_value = storage.get(key);
+        assert_eq!(Some(value), retrieved_value);
+    }
 }


### PR DESCRIPTION
This PR introduces the following changes:
1. Removes an old `todo` from the `test_value_absent_in_zk_storage`.
2. Introduces `is_merged` flag in `JmtStorage`, the flag ensures that we merged the storage before getting reads from the `batch_cache`