### PR TITLE
Allow Zk storage to finalize

### DIFF
--- a/demo-app/src/helpers.rs
+++ b/demo-app/src/helpers.rs
@@ -1,10 +1,11 @@
+use sha2::Sha256;
 use sov_modules_api::{mocks::MockContext, DispatchQuery};
 use sov_state::JmtStorage;
 use std::str;
 
 use crate::runtime::Runtime;
 
-pub(crate) fn check_query(query: Vec<u8>, expected_response: &str, storage: JmtStorage) {
+pub(crate) fn check_query(query: Vec<u8>, expected_response: &str, storage: JmtStorage<Sha256>) {
     let module = Runtime::<MockContext>::decode_query(&query).unwrap();
     let query_response = module.dispatch_query(storage);
 

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -81,7 +81,7 @@ pub struct MockContext {
 }
 
 impl Spec for MockContext {
-    type Storage = JmtStorage;
+    type Storage = JmtStorage<Self::Hasher>;
     type Hasher = sha2::Sha256;
     type PublicKey = MockPublicKey;
     type Signature = MockSignature;
@@ -103,7 +103,7 @@ pub struct ZkMockContext {
 }
 
 impl Spec for ZkMockContext {
-    type Storage = ZkStorage;
+    type Storage = ZkStorage<Self::Hasher>;
     type Hasher = sha2::Sha256;
     type PublicKey = MockPublicKey;
     type Signature = MockSignature;

--- a/sov-modules/sov-modules-impl/example-election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-election/src/tests.rs
@@ -17,8 +17,13 @@ fn test_election() {
     test_module::<MockContext>(native_storage.clone());
 
     native_storage.merge();
+    let first_reads = native_storage.get_first_reads();
+    native_storage.finalize();
+    let tree_read_log = native_storage
+        .take_treedb_log()
+        .expect("Tree read log must exist");
 
-    let zk_storage = ZkStorage::new(native_storage.get_first_reads());
+    let zk_storage = ZkStorage::new(first_reads, tree_read_log.into());
     test_module::<ZkMockContext>(zk_storage);
 }
 

--- a/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/example-value-setter/src/tests.rs
@@ -19,9 +19,11 @@ fn test_value_setter() {
         test_value_setter_helper(context, storage.clone());
     }
     storage.merge();
+    storage.finalize();
+    let tree_read_log = storage.take_treedb_log().unwrap();
     // Test Zk-Context
     {
-        let zk_storage = ZkStorage::new(storage.get_first_reads());
+        let zk_storage = ZkStorage::new(storage.get_first_reads(), tree_read_log.into());
         let zk_context = ZkMockContext::new(sender);
         test_value_setter_helper(zk_context, zk_storage);
     }
@@ -68,10 +70,12 @@ fn test_err_on_sender_is_not_admin() {
         test_err_on_sender_is_not_admin_helper(context, storage.clone());
     }
     storage.merge();
+    storage.finalize();
+    let tree_read_log = storage.take_treedb_log().unwrap();
 
     // Test Zk-Context
     {
-        let zk_storage = ZkStorage::new(storage.get_first_reads());
+        let zk_storage = ZkStorage::new(storage.get_first_reads(), tree_read_log.into());
         let zk_context = ZkMockContext::new(sender);
         test_err_on_sender_is_not_admin_helper(zk_context, zk_storage);
     }

--- a/sov-modules/sov-modules-impl/integration-tests/tests/nested_modules_tests.rs
+++ b/sov-modules/sov-modules-impl/integration-tests/tests/nested_modules_tests.rs
@@ -75,10 +75,12 @@ fn nested_module_call_test() {
         test_state_update::<MockContext>(native_storage.clone());
     }
     native_storage.merge();
+    native_storage.finalize();
+    let tree_read_log = native_storage.take_treedb_log().unwrap();
 
     // Test the `zk` execution.
     {
-        let zk_storage = ZkStorage::new(native_storage.get_first_reads());
+        let zk_storage = ZkStorage::new(native_storage.get_first_reads(), tree_read_log.into());
         execute_module_logic::<ZkMockContext>(zk_storage.clone());
         test_state_update::<ZkMockContext>(zk_storage);
     }

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -3,6 +3,7 @@ mod internal_cache;
 mod jmt_storage;
 mod map;
 pub mod storage;
+mod tree_db;
 mod utils;
 mod value;
 mod zk_storage;

--- a/sov-modules/sov-state/src/storage_test.rs
+++ b/sov-modules/sov-state/src/storage_test.rs
@@ -1,3 +1,5 @@
+use sha2::Sha256;
+
 use crate::{
     storage::{StorageKey, StorageValue},
     JmtStorage, Storage, ZkStorage,
@@ -10,21 +12,21 @@ fn test_value_absent_in_zk_storage() {
 
     let path = schemadb::temppath::TempPath::new();
     {
-        let mut storage = JmtStorage::with_path(&path).unwrap();
+        let mut storage = JmtStorage::<Sha256>::with_path(&path).unwrap();
         storage.set(key.clone(), value.clone());
         storage.merge();
         storage.finalize();
     }
 
     {
-        let mut storage = JmtStorage::with_path(&path).unwrap();
+        let mut storage = JmtStorage::<Sha256>::with_path(&path).unwrap();
         storage.get(key.clone());
         storage.merge();
 
         let reads = storage.get_first_reads();
 
         // Here we crate a new ZkStorage with an empty inner cache.
-        let storage = ZkStorage::new(reads);
+        let storage = ZkStorage::<Sha256>::new(reads);
         // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
         // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
         let retrieved_value = storage.get(key);

--- a/sov-modules/sov-state/src/storage_test.rs
+++ b/sov-modules/sov-state/src/storage_test.rs
@@ -2,6 +2,7 @@ use sha2::Sha256;
 
 use crate::{
     storage::{StorageKey, StorageValue},
+    tree_db::ZkTreeDb,
     JmtStorage, Storage, ZkStorage,
 };
 
@@ -11,12 +12,15 @@ fn test_value_absent_in_zk_storage() {
     let value = StorageValue::from("value");
 
     let path = schemadb::temppath::TempPath::new();
-    {
+    let zk_db: ZkTreeDb = {
         let mut storage = JmtStorage::<Sha256>::with_path(&path).unwrap();
         storage.set(key.clone(), value.clone());
         storage.merge();
         storage.finalize();
+        storage.take_treedb_log()
     }
+    .expect("Read log must be populated")
+    .into();
 
     {
         let mut storage = JmtStorage::<Sha256>::with_path(&path).unwrap();
@@ -26,7 +30,7 @@ fn test_value_absent_in_zk_storage() {
         let reads = storage.get_first_reads();
 
         // Here we crate a new ZkStorage with an empty inner cache.
-        let storage = ZkStorage::<Sha256>::new(reads);
+        let storage = ZkStorage::<Sha256>::new(reads, zk_db);
         // `storage.get` tries to fetch the value from the (empty) inner cache but it fails,
         // then it fallbacks to the `reads` we provided in the constructor of the ZkStorage.
         let retrieved_value = storage.get(key);

--- a/sov-modules/sov-state/src/tree_db.rs
+++ b/sov-modules/sov-state/src/tree_db.rs
@@ -1,0 +1,179 @@
+use std::{cell::RefCell, path::Path};
+
+use jmt::{
+    storage::{Node, TreeReader, TreeWriter},
+    KeyHash, OwnedValue, Version,
+};
+use sovereign_db::state_db::StateDB;
+
+use crate::{
+    storage::{StorageKey, StorageValue},
+    ValueReader,
+};
+
+#[derive(Clone)]
+pub struct TreeReadLogger {
+    is_recording: bool,
+    nodes: RefCell<Vec<Option<Node>>>,
+    values: RefCell<Vec<Option<OwnedValue>>>,
+    state_db: StateDB,
+}
+
+impl ValueReader for TreeReadLogger {
+    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
+        self.state_db.read_value(key)
+    }
+}
+
+impl Into<ZkTreeDb> for TreeReadLogger {
+    fn into(self) -> ZkTreeDb {
+        ZkTreeDb {
+            nodes: RefCell::new(self.nodes.take().into_iter()),
+            values: RefCell::new(self.values.take().into_iter()),
+            next_version: self.get_next_version(),
+        }
+    }
+}
+
+impl TreeReadLogger {
+    /// Creates a tree read logger wrapping the provided StateDB.
+    /// The logger is recording by default
+    pub fn with_db(db: StateDB) -> Self {
+        Self {
+            is_recording: true,
+            nodes: Default::default(),
+            values: Default::default(),
+            state_db: db,
+        }
+    }
+
+    /// Opens a StateDB at the provided path, and creates a new logger wrapping it.
+    /// The logger is recording by default
+    pub fn with_path(path: impl AsRef<Path>) -> Result<Self, anyhow::Error> {
+        let db = StateDB::with_path(path)?;
+        Ok(Self::with_db(db))
+    }
+
+    /// Creates a tree read logger wrapping a temporary StateDB.
+    /// The logger is recording by default
+    #[cfg(any(test, feature = "temp"))]
+    pub fn temporary() -> Self {
+        let db = StateDB::temporary();
+        Self::with_db(db)
+    }
+
+    /// Causes the tree read logger to start recording, if it wasn't already.
+    /// This incurs one `clone` of any item read from the StateDB using the
+    /// `TreeReader` trait.
+    #[allow(unused)]
+    pub fn start_recording(&mut self) {
+        self.is_recording = true
+    }
+
+    /// Causes the tree read logger to stop recording if it was previously running.
+    /// Disabling recording. A logger that is not recording adds no overhead per-read except for a single comparison.
+    #[allow(unused)]
+    pub fn stop_recording(&mut self) {
+        self.is_recording = false
+    }
+
+    pub fn put_preimage(&self, key_hash: KeyHash, key: &Vec<u8>) -> Result<(), anyhow::Error> {
+        self.state_db.put_preimage(key_hash, key)
+    }
+
+    pub fn get_next_version(&self) -> Version {
+        self.state_db.get_next_version()
+    }
+
+    pub fn inc_next_version(&self) {
+        self.state_db.inc_next_version()
+    }
+}
+
+impl TreeReader for TreeReadLogger {
+    fn get_node_option(
+        &self,
+        node_key: &jmt::storage::NodeKey,
+    ) -> anyhow::Result<Option<jmt::storage::Node>> {
+        let node_opt = self.state_db.get_node_option(node_key)?;
+        if self.is_recording {
+            self.nodes.borrow_mut().push(node_opt.clone())
+        }
+        Ok(node_opt)
+    }
+
+    fn get_value_option(
+        &self,
+        max_version: jmt::Version,
+        key_hash: jmt::KeyHash,
+    ) -> anyhow::Result<Option<OwnedValue>> {
+        let value_opt = self.state_db.get_value_option(max_version, key_hash)?;
+        if self.is_recording {
+            self.values.borrow_mut().push(value_opt.clone())
+        }
+        Ok(value_opt)
+    }
+
+    fn get_rightmost_leaf(
+        &self,
+    ) -> anyhow::Result<Option<(jmt::storage::NodeKey, jmt::storage::LeafNode)>> {
+        self.state_db.get_rightmost_leaf()
+    }
+}
+
+impl TreeWriter for TreeReadLogger {
+    fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> anyhow::Result<()> {
+        self.state_db.write_node_batch(node_batch)
+    }
+}
+
+/// A ZkTreeDb is just a log of the values read by another TreeReader while executing
+/// a particular sequence of jmt operations. It can can be used to emulate a TreeReader
+/// when performing the same sequence of operations in the zk context.
+pub struct ZkTreeDb {
+    nodes: RefCell<std::vec::IntoIter<Option<Node>>>,
+    values: RefCell<std::vec::IntoIter<Option<OwnedValue>>>,
+    pub next_version: Version,
+}
+
+impl ZkTreeDb {
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        ZkTreeDb {
+            nodes: RefCell::new(vec![].into_iter()),
+            values: RefCell::new(vec![].into_iter()),
+            next_version: 0,
+        }
+    }
+}
+
+impl TreeReader for ZkTreeDb {
+    fn get_node_option(
+        &self,
+        _node_key: &jmt::storage::NodeKey,
+    ) -> anyhow::Result<Option<jmt::storage::Node>> {
+        Ok(self
+            .nodes
+            .borrow_mut()
+            .next()
+            .expect("Read must have been recorded"))
+    }
+
+    fn get_value_option(
+        &self,
+        _max_version: jmt::Version,
+        _key_hash: jmt::KeyHash,
+    ) -> anyhow::Result<Option<jmt::OwnedValue>> {
+        Ok(self
+            .values
+            .borrow_mut()
+            .next()
+            .expect("Read must have been recorded"))
+    }
+
+    fn get_rightmost_leaf(
+        &self,
+    ) -> anyhow::Result<Option<(jmt::storage::NodeKey, jmt::storage::LeafNode)>> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This PR is marked as a draft because of some open design questions. Currently, the APIs are brittle and very sensitive to the ordering of different calls. For example, each of these three calls has a differen result!

```rust
// This version is correct
jmt_storage.get_first_reads(); 
jmt_storage.finalize();
jmt_storage.take_treedb_log();
```

```rust
// This version returns an empty FirstReads
jmt_storage.finalize();
jmt_storage.get_first_reads();
jmt_storage.take_treedb_log();
```

```rust
// This version panics
jmt_storage.take_treedb_log();
jmt_storage.finalize();
jmt_storage.get_first_reads();
```

I've opened this as a draft anyway for a few reasons: 
- We can use it temporarily to set up a demo for tomorrow, even though we probably won't merge the current design
- I hope that it sparks a useful discussion about how to set up host->guest interaction