### PR TITLE
Adds `remove` method to `StateValue` and `StateMap`

### DIFF
--- a/sov-modules/sov-state/src/backend.rs
+++ b/sov-modules/sov-state/src/backend.rs
@@ -41,4 +41,10 @@ impl<K: Encode, V: Encode + Decode, S: Storage> Backend<K, V, S> {
                 .unwrap_or_else(|e| panic!("Unable to deserialize storage value {e:?}")),
         )
     }
+
+    pub(crate) fn remove_value(&mut self, storage_key: StorageKey) -> Option<V> {
+        let storage_value = self.get_value(storage_key.clone())?;
+        self.storage.delete(storage_key);
+        Some(storage_value)
+    }
 }

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -9,6 +9,10 @@ mod zk_storage;
 
 #[cfg(test)]
 mod storage_test;
+
+#[cfg(test)]
+mod state_tests;
+
 pub use first_read_last_write_cache::cache::CacheLog;
 pub use internal_cache::ValueReader;
 pub use jmt_storage::{delete_storage, JmtStorage};

--- a/sov-modules/sov-state/src/state_tests.rs
+++ b/sov-modules/sov-state/src/state_tests.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::*;
 use crate::JmtStorage;
 
@@ -68,8 +70,8 @@ fn create_storage_operations() -> Vec<(StorageOperation, StorageOperation)> {
 fn create_state_map_and_storage(
     key: u32,
     value: u32,
+    path: impl AsRef<Path>,
 ) -> (StateMap<u32, u32, JmtStorage>, JmtStorage) {
-    let path = schemadb::temppath::TempPath::new();
     let storage = JmtStorage::with_path(&path).unwrap();
 
     let mut state_map = StateMap::new(storage.clone(), Prefix::new(vec![0]));
@@ -79,10 +81,11 @@ fn create_state_map_and_storage(
 
 #[test]
 fn test_state_map() {
+    let path = schemadb::temppath::TempPath::new();
     for (before_remove, after_remove) in create_storage_operations() {
         let key = 1;
         let value = 11;
-        let (mut state_map, storage) = create_state_map_and_storage(key, value);
+        let (mut state_map, storage) = create_state_map_and_storage(key, value, &path);
 
         before_remove.execute(storage.clone());
         assert_eq!(state_map.remove(&key).unwrap(), value);
@@ -92,8 +95,10 @@ fn test_state_map() {
     }
 }
 
-fn create_state_value_and_storage(value: u32) -> (StateValue<u32, JmtStorage>, JmtStorage) {
-    let path = schemadb::temppath::TempPath::new();
+fn create_state_value_and_storage(
+    value: u32,
+    path: impl AsRef<Path>,
+) -> (StateValue<u32, JmtStorage>, JmtStorage) {
     let storage = JmtStorage::with_path(&path).unwrap();
 
     let mut state_value = StateValue::new(storage.clone(), Prefix::new(vec![0]));
@@ -103,9 +108,10 @@ fn create_state_value_and_storage(value: u32) -> (StateValue<u32, JmtStorage>, J
 
 #[test]
 fn test_state_value() {
+    let path = schemadb::temppath::TempPath::new();
     for (before_remove, after_remove) in create_storage_operations() {
         let value = 11;
-        let (mut state_value, storage) = create_state_value_and_storage(value);
+        let (mut state_value, storage) = create_state_value_and_storage(value, &path);
 
         before_remove.execute(storage.clone());
         assert_eq!(state_value.remove().unwrap(), value);

--- a/sov-modules/sov-state/src/state_tests.rs
+++ b/sov-modules/sov-state/src/state_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use crate::JmtStorage;
+
+enum Operation {
+    Merge,
+    Finalize,
+}
+
+impl Operation {
+    fn execute(&self, storage: &mut JmtStorage) {
+        match self {
+            Operation::Merge => storage.merge(),
+            Operation::Finalize => {
+                storage.finalize();
+            }
+        }
+    }
+}
+
+struct StorageOperation {
+    operations: Vec<Operation>,
+}
+
+impl StorageOperation {
+    fn execute(&self, storage: JmtStorage) {
+        for op in self.operations.iter() {
+            op.execute(&mut storage.clone())
+        }
+    }
+}
+
+fn create_storage_operations() -> Vec<(StorageOperation, StorageOperation)> {
+    // Test cases for various interweavings of storage operations.
+    vec![
+        (
+            StorageOperation { operations: vec![] },
+            StorageOperation { operations: vec![] },
+        ),
+        (
+            StorageOperation {
+                operations: vec![Operation::Merge],
+            },
+            StorageOperation { operations: vec![] },
+        ),
+        (
+            StorageOperation {
+                operations: vec![Operation::Merge, Operation::Finalize],
+            },
+            StorageOperation { operations: vec![] },
+        ),
+        (
+            StorageOperation {
+                operations: vec![Operation::Merge],
+            },
+            StorageOperation {
+                operations: vec![Operation::Finalize],
+            },
+        ),
+        (
+            StorageOperation { operations: vec![] },
+            StorageOperation {
+                operations: vec![Operation::Merge, Operation::Finalize],
+            },
+        ),
+    ]
+}
+
+fn create_state_map_and_storage(
+    key: u32,
+    value: u32,
+) -> (StateMap<u32, u32, JmtStorage>, JmtStorage) {
+    let path = schemadb::temppath::TempPath::new();
+    let storage = JmtStorage::with_path(&path).unwrap();
+
+    let mut state_map = StateMap::new(storage.clone(), Prefix::new(vec![0]));
+    state_map.set(&key, value);
+    (state_map, storage)
+}
+
+#[test]
+fn test_state_map() {
+    for (before_remove, after_remove) in create_storage_operations() {
+        let key = 1;
+        let value = 11;
+        let (mut state_map, storage) = create_state_map_and_storage(key, value);
+
+        before_remove.execute(storage.clone());
+        assert_eq!(state_map.remove(&key).unwrap(), value);
+
+        after_remove.execute(storage);
+        assert!(state_map.get(&key).is_none())
+    }
+}
+
+fn create_state_value_and_storage(value: u32) -> (StateValue<u32, JmtStorage>, JmtStorage) {
+    let path = schemadb::temppath::TempPath::new();
+    let storage = JmtStorage::with_path(&path).unwrap();
+
+    let mut state_value = StateValue::new(storage.clone(), Prefix::new(vec![0]));
+    state_value.set(value);
+    (state_value, storage)
+}
+
+#[test]
+fn test_state_value() {
+    for (before_remove, after_remove) in create_storage_operations() {
+        let value = 11;
+        let (mut state_value, storage) = create_state_value_and_storage(value);
+
+        before_remove.execute(storage.clone());
+        assert_eq!(state_value.remove().unwrap(), value);
+
+        after_remove.execute(storage);
+        assert!(state_value.get().is_none())
+    }
+}

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -51,7 +51,20 @@ impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
 
     /// Gets a value from the StateValue or Error if the value is absent.
     pub fn get_or_err(&self) -> Result<V, Error> {
-        self.get().ok_or(Error::MissingValue(self.prefix().clone()))
+        self.get()
+            .ok_or_else(|| Error::MissingValue(self.prefix().clone()))
+    }
+
+    // Removes a value from the StateValue, returning the value (or None if the key is absent).
+    pub fn remove(&mut self) -> Option<V> {
+        let storage_key = StorageKey::new(self.backend.prefix(), &SingletonKey);
+        self.backend.remove_value(storage_key)
+    }
+
+    // Removes a value and from the StateValue, returning the value (or Error if the key is absent).
+    pub fn remove_or_err(&mut self) -> Result<V, Error> {
+        self.remove()
+            .ok_or_else(|| Error::MissingValue(self.prefix().clone()))
     }
 
     pub fn prefix(&self) -> &Prefix {


### PR DESCRIPTION
This PR introduces the following changes:
1. Adds `remove` method to `StateValue` and `StateMap`
2. Introduces  tests for the new `remove` method with different interweavings of `Storage::merge and Storage::finalize`