### PR TITLE
Add `Accounts` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 	"sov-modules/sov-modules-macros",
 	"sov-modules/sov-state",
 	"sov-modules/sov-modules-api",
+	"sov-modules/sov-modules-impl/accounts",
 	"sov-modules/sov-modules-impl/examples/value-setter",
 	"sov-modules/sov-modules-impl/examples/election",
 	"sov-modules/sov-modules-impl/integration-tests",

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -19,6 +19,7 @@ use std::fmt::Debug;
 
 use thiserror::Error;
 
+/// Represents an address in the rollup.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Copy, Clone)]
 pub struct Address {
     addr: [u8; 32],
@@ -42,6 +43,7 @@ pub enum SigVerificationError {
     BadSignature,
 }
 
+/// Signature used in the module system.
 pub trait Signature {
     type PublicKey;
 
@@ -56,6 +58,7 @@ pub trait Signature {
 #[derive(Debug)]
 pub enum NonInstantiable {}
 
+/// PublicKey used in the module system.
 pub trait PublicKey {
     fn to_address(&self) -> Address;
 }

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -19,6 +19,23 @@ use std::fmt::Debug;
 
 use thiserror::Error;
 
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Copy, Clone)]
+pub struct Address {
+    addr: [u8; 32],
+}
+
+impl Address {
+    pub fn inner(&self) -> [u8; 32] {
+        self.addr
+    }
+}
+
+impl Address {
+    pub fn new(addr: [u8; 32]) -> Self {
+        Self { addr }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum SigVerificationError {
     #[error("Bad signature")]
@@ -48,7 +65,8 @@ pub trait Spec {
         + Eq
         + TryFrom<&'static str>
         + Clone
-        + Debug;
+        + Debug
+        + TryInto<Address, Error = ()>;
 
     type Hasher: jmt::SimpleHasher;
 

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -56,6 +56,10 @@ pub trait Signature {
 #[derive(Debug)]
 pub enum NonInstantiable {}
 
+pub trait PublicKey {
+    fn to_address(&self) -> Address;
+}
+
 /// Spec contains types common for all modules.
 pub trait Spec {
     type Storage: Storage + Clone;
@@ -66,7 +70,7 @@ pub trait Spec {
         + TryFrom<&'static str>
         + Clone
         + Debug
-        + TryInto<Address, Error = ()>;
+        + PublicKey;
 
     type Hasher: jmt::SimpleHasher;
 

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -1,5 +1,6 @@
-use crate::{Context, SigVerificationError, Signature, Spec};
+use crate::{Address, Context, SigVerificationError, Signature, Spec};
 use borsh::{BorshDeserialize, BorshSerialize};
+use jmt::SimpleHasher;
 use sov_state::{JmtStorage, ZkStorage};
 use std::convert::Infallible;
 
@@ -21,6 +22,15 @@ impl TryFrom<&'static str> for MockPublicKey {
     fn try_from(key: &'static str) -> Result<Self, Self::Error> {
         let key = key.as_bytes().to_vec();
         Ok(Self { pub_key: key })
+    }
+}
+
+impl TryFrom<MockPublicKey> for Address {
+    type Error = ();
+
+    fn try_from(value: MockPublicKey) -> Result<Self, Self::Error> {
+        let pub_key_has = <MockContext as Spec>::Hasher::hash(&value.pub_key);
+        Ok(Address::new(pub_key_has))
     }
 }
 

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -14,6 +14,10 @@ impl MockPublicKey {
     pub fn new(pub_key: Vec<u8>) -> Self {
         Self { pub_key }
     }
+
+    pub fn sign(&self, _msg: [u8; 32]) -> MockSignature {
+        MockSignature { msg_sig: vec![] }
+    }
 }
 
 impl TryFrom<&'static str> for MockPublicKey {

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Context, SigVerificationError, Signature, Spec};
+use crate::{Address, Context, PublicKey, SigVerificationError, Signature, Spec};
 use borsh::{BorshDeserialize, BorshSerialize};
 use jmt::SimpleHasher;
 use sov_state::{JmtStorage, ZkStorage};
@@ -25,12 +25,10 @@ impl TryFrom<&'static str> for MockPublicKey {
     }
 }
 
-impl TryFrom<MockPublicKey> for Address {
-    type Error = ();
-
-    fn try_from(value: MockPublicKey) -> Result<Self, Self::Error> {
-        let pub_key_has = <MockContext as Spec>::Hasher::hash(&value.pub_key);
-        Ok(Address::new(pub_key_has))
+impl PublicKey for MockPublicKey {
+    fn to_address(&self) -> Address {
+        let pub_key_hash = <MockContext as Spec>::Hasher::hash(&self.pub_key);
+        Address::new(pub_key_hash)
     }
 }
 

--- a/sov-modules/sov-modules-impl/accounts/Cargo.toml
+++ b/sov-modules/sov-modules-impl/accounts/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "accounts"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+sov-modules-api = { workspace = true ,  features = ["mocks"]}
+sov-state = { workspace = true, features = ["temp"] }
+
+[dependencies]
+anyhow = { workspace = true }
+sov-modules-api = { workspace = true }
+sov-modules-macros = { workspace = true }
+sov-state = { workspace = true }
+sovereign-sdk = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true }
+borsh = { workspace = true, features = ["rc"]}
+hex = { workspace = true }
+
+
+[features]
+default = ["native"]
+serde = ["dep:serde", "dep:serde_json"]
+native = ["serde"]

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -1,10 +1,8 @@
-use crate::Account;
-
 use super::Accounts;
-
+use crate::Account;
 use anyhow::Result;
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_modules_api::{Address, CallResponse};
+use sov_modules_api::{Address, CallResponse, PublicKey};
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub enum CallMessage<C: sov_modules_api::Context> {
@@ -12,18 +10,10 @@ pub enum CallMessage<C: sov_modules_api::Context> {
     UpdatePublicKey(C::PublicKey),
 }
 
-/*
-1. Create pub_key => addr
-2. Change pub_key => new_pub_key
-3. Create pub_key => addr
- */
-
-//TODO add remove account
-
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
         self.exit_if_account_exist(context.sender())?;
-        let default_address = context.sender().clone().try_into().unwrap();
+        let default_address = context.sender().to_address();
 
         self.exit_if_address_exist(&default_address)?;
 

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -13,8 +13,8 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
         self.exit_if_account_exist(context.sender())?;
-        let default_address = context.sender().to_address();
 
+        let default_address = context.sender().to_address();
         self.exit_if_address_exist(&default_address)?;
 
         let new_account = Account {
@@ -23,6 +23,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         };
 
         self.accounts.set(context.sender(), new_account);
+
         self.addresses
             .set(&default_address, context.sender().clone());
 
@@ -36,12 +37,14 @@ impl<C: sov_modules_api::Context> Accounts<C> {
     ) -> Result<CallResponse> {
         self.exit_if_account_exist(&new_pub_key)?;
 
-        let account = self.accounts.remove_or_err(context.sender())?;
-        // We don't reset the nonce
-        self.accounts.set(&new_pub_key, account);
+        // Only the public key is updated, but account data remains the same.
 
+        let account = self.accounts.remove_or_err(context.sender())?;
+        self.accounts.set(&new_pub_key, account);
         self.addresses.remove_or_err(&account.addr)?;
         self.addresses.set(&account.addr, new_pub_key);
+
+        // TODO proof of possesion
 
         Ok(CallResponse::default())
     }

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -5,7 +5,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::Signature;
 use sov_modules_api::{Address, CallResponse, PublicKey};
 
-pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [0; 32];
+pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub enum CallMessage<C: sov_modules_api::Context> {
@@ -18,10 +18,10 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
-        self.exit_if_account_exist(context.sender())?;
+        self.exit_if_account_exists(context.sender())?;
 
         let default_address = context.sender().to_address();
-        self.exit_if_address_exist(&default_address)?;
+        self.exit_if_address_exists(&default_address)?;
 
         let new_account = Account {
             addr: default_address,
@@ -42,7 +42,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         signature: C::Signature,
         context: &C,
     ) -> Result<CallResponse> {
-        self.exit_if_account_exist(&new_pub_key)?;
+        self.exit_if_account_exists(&new_pub_key)?;
 
         let account = self.accounts.remove_or_err(context.sender())?;
 
@@ -62,7 +62,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         Ok(CallResponse::default())
     }
 
-    fn exit_if_account_exist(&self, new_pub_key: &C::PublicKey) -> Result<()> {
+    fn exit_if_account_exists(&self, new_pub_key: &C::PublicKey) -> Result<()> {
         anyhow::ensure!(
             self.accounts.get(new_pub_key).is_none(),
             "New PublicKey already exists"
@@ -70,7 +70,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         Ok(())
     }
 
-    fn exit_if_address_exist(&self, address: &Address) -> Result<()> {
+    fn exit_if_address_exists(&self, address: &Address) -> Result<()> {
         anyhow::ensure!(
             self.public_keys.get(address).is_none(),
             "Address already exists"

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -18,6 +18,8 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 3. Create pub_key => addr
  */
 
+//TODO add remove account
+
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
         self.exit_if_account_exist(context.sender())?;

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -1,0 +1,35 @@
+use crate::Address;
+
+use super::Accounts;
+
+use anyhow::{anyhow, bail, ensure, Result};
+use borsh::{BorshDeserialize, BorshSerialize};
+use sov_modules_api::CallResponse;
+
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
+pub enum CallMessage<C: sov_modules_api::Context> {
+    CreateAccount,
+    UpdatePublicKey(C::PublicKey),
+}
+
+impl<C: sov_modules_api::Context> Accounts<C> {
+    pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
+        todo!()
+    }
+
+    pub(crate) fn update_public_key(
+        &mut self,
+        new_pub_key: C::PublicKey,
+        context: &C,
+    ) -> Result<CallResponse> {
+        anyhow::ensure!(
+            self.accounts.get(&new_pub_key).is_none(),
+            "New Public Key already exists"
+        );
+
+        let account = self.accounts.get_or_err(context.sender())?;
+        self.accounts.set(&new_pub_key, account);
+
+        Ok(CallResponse::default())
+    }
+}

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -1,5 +1,5 @@
-use super::Accounts;
 use crate::Account;
+use crate::Accounts;
 use anyhow::Result;
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::{Address, CallResponse, PublicKey};

--- a/sov-modules/sov-modules-impl/accounts/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/genesis.rs
@@ -1,0 +1,9 @@
+use crate::Accounts;
+use anyhow::Result;
+
+impl<C: sov_modules_api::Context> Accounts<C> {
+    pub(crate) fn init_module(&mut self) -> Result<()> {
+        // TODO read initial accounts from "Config"
+        Ok(())
+    }
+}

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -1,0 +1,63 @@
+mod call;
+mod genesis;
+mod query;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use sov_modules_api::Error;
+use sov_modules_macros::ModuleInfo;
+
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
+pub struct Address {
+    addr: [u8; 32],
+}
+
+impl Address {
+    pub fn new<C: sov_modules_api::Context>(pub_key: &C::PublicKey) -> Self {
+        todo!()
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
+struct Account {
+    addr: Address,
+    nonce: u64,
+}
+
+#[derive(ModuleInfo)]
+pub struct Accounts<C: sov_modules_api::Context> {
+    #[state]
+    pub(crate) addresses: sov_state::StateMap<Address, C::PublicKey, C::Storage>,
+
+    #[state]
+    pub(crate) accounts: sov_state::StateMap<C::PublicKey, Account, C::Storage>,
+}
+
+impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
+    type Context = C;
+
+    type CallMessage = sov_modules_api::NonInstantiable;
+
+    type QueryMessage = query::QueryMessage<C>;
+    // Add PreCheck
+
+    fn genesis(&mut self) -> Result<(), Error> {
+        Ok(self.init_module()?)
+    }
+
+    fn call(
+        &mut self,
+        msg: Self::CallMessage,
+        context: &Self::Context,
+    ) -> Result<sov_modules_api::CallResponse, Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "native")]
+    fn query(&self, msg: Self::QueryMessage) -> sov_modules_api::QueryResponse {
+        match msg {
+            query::QueryMessage::GetAccount(pub_key) => self.get_account(pub_key),
+        };
+        todo!()
+    }
+}

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -17,7 +17,7 @@ struct Account {
 #[derive(ModuleInfo)]
 pub struct Accounts<C: sov_modules_api::Context> {
     #[state]
-    pub(crate) addresses: sov_state::StateMap<Address, C::PublicKey, C::Storage>,
+    pub(crate) public_keys: sov_state::StateMap<Address, C::PublicKey, C::Storage>,
 
     #[state]
     pub(crate) accounts: sov_state::StateMap<C::PublicKey, Account, C::Storage>,
@@ -41,8 +41,8 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
     ) -> Result<sov_modules_api::CallResponse, Error> {
         match msg {
             call::CallMessage::CreateAccount => Ok(self.create_account(context)?),
-            call::CallMessage::UpdatePublicKey(new_pub_key) => {
-                Ok(self.update_public_key(new_pub_key, context)?)
+            call::CallMessage::UpdatePublicKey(new_pub_key, sig) => {
+                Ok(self.update_public_key(new_pub_key, sig, context)?)
             }
         }
     }

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -1,9 +1,10 @@
 mod call;
 mod genesis;
 mod query;
+#[cfg(test)]
+mod tests;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-
 use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
@@ -53,7 +54,6 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
                 let response = serde_json::to_vec(&self.get_account(pub_key)).unwrap();
                 sov_modules_api::QueryResponse { response }
             }
-        };
-        todo!()
+        }
     }
 }

--- a/sov-modules/sov-modules-impl/accounts/src/query.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/query.rs
@@ -9,14 +9,14 @@ pub enum QueryMessage<C: sov_modules_api::Context> {
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
 pub enum Response {
-    AccountExist { addr: [u8; 32], nonce: u64 },
+    AccountExists { addr: [u8; 32], nonce: u64 },
     AccountEmpty,
 }
 
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn get_account(&self, pub_key: C::PublicKey) -> Response {
         match self.accounts.get(&pub_key) {
-            Some(Account { addr, nonce }) => Response::AccountExist {
+            Some(Account { addr, nonce }) => Response::AccountExists {
                 addr: addr.inner(),
                 nonce,
             },

--- a/sov-modules/sov-modules-impl/accounts/src/query.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/query.rs
@@ -1,0 +1,26 @@
+use crate::{Account, Accounts};
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::Deserialize;
+
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
+pub enum QueryMessage<C: sov_modules_api::Context> {
+    GetAccount(C::PublicKey),
+}
+
+#[derive(Deserialize, Debug, Eq, PartialEq)]
+pub enum Response {
+    AccountExist { addr: [u8; 32], nonce: u64 },
+    AccountEmpty,
+}
+
+impl<C: sov_modules_api::Context> Accounts<C> {
+    pub(crate) fn get_account(&self, pub_key: C::PublicKey) -> Response {
+        match self.accounts.get(&pub_key) {
+            Some(Account { addr, nonce }) => Response::AccountExist {
+                addr: addr.addr,
+                nonce,
+            },
+            None => Response::AccountEmpty,
+        }
+    }
+}

--- a/sov-modules/sov-modules-impl/accounts/src/query.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/query.rs
@@ -1,13 +1,13 @@
 use crate::{Account, Accounts};
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub enum QueryMessage<C: sov_modules_api::Context> {
     GetAccount(C::PublicKey),
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
 pub enum Response {
     AccountExist { addr: [u8; 32], nonce: u64 },
     AccountEmpty,
@@ -17,7 +17,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn get_account(&self, pub_key: C::PublicKey) -> Response {
         match self.accounts.get(&pub_key) {
             Some(Account { addr, nonce }) => Response::AccountExist {
-                addr: addr.addr,
+                addr: addr.inner(),
                 nonce,
             },
             None => Response::AccountEmpty,

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -1,0 +1,107 @@
+use crate::{
+    call,
+    query::{self, QueryMessage},
+    Accounts,
+};
+use sov_modules_api::{
+    mocks::{MockContext, MockPublicKey},
+    Address, Context, Module, ModuleInfo,
+};
+use sov_state::JmtStorage;
+
+type C = MockContext;
+
+#[test]
+fn test_update_account() {
+    let native_storage = JmtStorage::temporary();
+    let accounts = &mut Accounts::<C>::new(native_storage);
+
+    let sender = MockPublicKey::try_from("pub_key").unwrap();
+    let sender_addr = TryInto::<Address>::try_into(sender.clone()).unwrap();
+    let sender_context = C::new(sender.clone());
+
+    // Test new account creation
+    {
+        accounts
+            .call(call::CallMessage::<C>::CreateAccount, &sender_context)
+            .unwrap();
+
+        let query_response: query::Response = serde_json::from_slice(
+            &accounts
+                .query(QueryMessage::GetAccount(sender.clone()))
+                .response,
+        )
+        .unwrap();
+
+        assert_eq!(
+            query_response,
+            query::Response::AccountExist {
+                addr: sender_addr.inner(),
+                nonce: 0
+            }
+        )
+    }
+
+    // Test public key update
+    {
+        let new_pub_key = MockPublicKey::try_from("new_pub_key").unwrap();
+
+        accounts
+            .call(
+                call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone()),
+                &sender_context,
+            )
+            .unwrap();
+
+        // Account corresponding to the old public key does not exist
+        let query_response: query::Response =
+            serde_json::from_slice(&accounts.query(QueryMessage::GetAccount(sender)).response)
+                .unwrap();
+
+        assert_eq!(query_response, query::Response::AccountEmpty);
+
+        // New account with the new public key and an old address is created.
+        let query_response: query::Response = serde_json::from_slice(
+            &accounts
+                .query(QueryMessage::GetAccount(new_pub_key))
+                .response,
+        )
+        .unwrap();
+
+        assert_eq!(
+            query_response,
+            query::Response::AccountExist {
+                addr: sender_addr.inner(),
+                nonce: 0
+            }
+        )
+    }
+}
+
+#[test]
+fn test_update_account_fails() {
+    let native_storage = JmtStorage::temporary();
+    let accounts = &mut Accounts::<C>::new(native_storage);
+
+    let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
+    let sender_context_1 = C::new(sender_1);
+
+    accounts
+        .call(call::CallMessage::<C>::CreateAccount, &sender_context_1)
+        .unwrap();
+
+    let sender_2 = MockPublicKey::try_from("pub_key_2").unwrap();
+    let sender_context_2 = C::new(sender_2.clone());
+
+    accounts
+        .call(call::CallMessage::<C>::CreateAccount, &sender_context_2)
+        .unwrap();
+
+    // The new public key already exists and the call fails.
+    assert!(accounts
+        .call(
+            call::CallMessage::<C>::UpdatePublicKey(sender_2),
+            &sender_context_1,
+        )
+        .is_err())
+}

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -35,7 +35,7 @@ fn test_update_account() {
 
         assert_eq!(
             query_response,
-            query::Response::AccountExist {
+            query::Response::AccountExists {
                 addr: sender_addr.inner(),
                 nonce: 0
             }
@@ -70,7 +70,7 @@ fn test_update_account() {
 
         assert_eq!(
             query_response,
-            query::Response::AccountExist {
+            query::Response::AccountExists {
                 addr: sender_addr.inner(),
                 nonce: 0
             }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -45,10 +45,10 @@ fn test_update_account() {
     // Test public key update
     {
         let new_pub_key = MockPublicKey::try_from("new_pub_key").unwrap();
-
+        let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
         accounts
             .call(
-                call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone()),
+                call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
                 &sender_context,
             )
             .unwrap();
@@ -91,6 +91,7 @@ fn test_update_account_fails() {
         .unwrap();
 
     let sender_2 = MockPublicKey::try_from("pub_key_2").unwrap();
+    let sig_2 = sender_2.sign(call::UPDATE_ACCOUNT_MSG);
     let sender_context_2 = C::new(sender_2.clone());
 
     accounts
@@ -100,7 +101,7 @@ fn test_update_account_fails() {
     // The new public key already exists and the call fails.
     assert!(accounts
         .call(
-            call::CallMessage::<C>::UpdatePublicKey(sender_2),
+            call::CallMessage::<C>::UpdatePublicKey(sender_2, sig_2),
             &sender_context_1,
         )
         .is_err())
@@ -119,9 +120,10 @@ fn test_create_account_fails() {
         .unwrap();
 
     let new_pub_key = MockPublicKey::try_from("pub_key_2").unwrap();
+    let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
     accounts
         .call(
-            call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone()),
+            call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
             &sender_context_1,
         )
         .unwrap();

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey},
-    Address, Context, Module, ModuleInfo,
+    Address, Context, Module, ModuleInfo, PublicKey,
 };
 use sov_state::JmtStorage;
 
@@ -17,7 +17,7 @@ fn test_update_account() {
     let accounts = &mut Accounts::<C>::new(native_storage);
 
     let sender = MockPublicKey::try_from("pub_key").unwrap();
-    let sender_addr = TryInto::<Address>::try_into(sender.clone()).unwrap();
+    let sender_addr: Address = sender.to_address();
     let sender_context = C::new(sender.clone());
 
     // Test new account creation

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -105,3 +105,31 @@ fn test_update_account_fails() {
         )
         .is_err())
 }
+
+#[test]
+fn test_create_account_fails() {
+    let native_storage = JmtStorage::temporary();
+    let accounts = &mut Accounts::<C>::new(native_storage);
+
+    let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
+    let sender_context_1 = C::new(sender_1);
+
+    accounts
+        .call(call::CallMessage::<C>::CreateAccount, &sender_context_1)
+        .unwrap();
+
+    let new_pub_key = MockPublicKey::try_from("pub_key_2").unwrap();
+    accounts
+        .call(
+            call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone()),
+            &sender_context_1,
+        )
+        .unwrap();
+
+    let sender_context_2 = C::new(new_pub_key);
+
+    // Account creation fails because the `new_pub_key` is already registered.
+    assert!(accounts
+        .call(call::CallMessage::<C>::CreateAccount, &sender_context_2)
+        .is_err())
+}


### PR DESCRIPTION
This PR introduces the following changes:
1. `Accounts` module, which keeps track of users `PublicKeys, Addresses, and Nonces`
2. Tests for the accounts module.

Missing:
1. Integration with the `DemoApp`
2. `Nonce` update (will be done with 1)
3. Documentation will be done once we have the `MultiSig` (it may introduce some changes to the `Accounts`)