### PR TITLE
`DemoApp` and `Accounts` integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ sha2 = "0.10.6"
 thiserror = "1.0.38"
 tiny-keccak = "2.0.2"
 tracing = "0.1.37"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sovereign-sdk = {path= "sdk" }
 first-read-last-write-cache = {path = "first-read-last-write-cache"}
 election = { path = "sov-modules/sov-modules-impl/examples/election" }
 value-setter = { path = "sov-modules/sov-modules-impl/examples/value-setter" }
+accounts = { path = "sov-modules/sov-modules-impl/accounts" }
 schemadb = {path = "db/schemadb"}
 sovereign-db = {path = "db/sovereign-db"}
 sov-state = {path = "sov-modules/sov-state"}

--- a/demo-app/Cargo.toml
+++ b/demo-app/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { workspace = true }
 sovereign-sdk = { workspace = true, features = ["mocks"] }
 election = { workspace = true }
 value-setter = { workspace = true }
+accounts = { workspace = true }
 sov-state = { workspace = true, features = ["temp"] }
 sovereign-db = { workspace = true }
 sov-modules-api = { workspace = true, features = ["mocks"] }

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use borsh::BorshSerialize;
 use sov_modules_api::mocks::{MockContext, MockPublicKey, MockSignature};
+use sov_modules_api::PublicKey;
 
 pub(crate) fn simulate_da() -> Vec<RawTx> {
     let mut messages = Vec::default();
@@ -21,7 +22,7 @@ impl CallGenerator {
 
         let admin = MockPublicKey::try_from("admin").unwrap();
 
-        let set_candidates_message = election::call::CallMessage::<MockContext>::SetCandidates {
+        let set_candidates_message = election::call::CallMessage::SetCandidates {
             names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
         };
 
@@ -34,16 +35,15 @@ impl CallGenerator {
         ];
 
         for voter in voters {
-            let add_voter_message =
-                election::call::CallMessage::<MockContext>::AddVoter(voter.clone());
+            let add_voter_message = election::call::CallMessage::AddVoter(voter.to_address());
 
             messages.push((admin.clone(), add_voter_message));
 
-            let vote_message = election::call::CallMessage::<MockContext>::Vote(1);
+            let vote_message = election::call::CallMessage::Vote(1);
             messages.push((voter, vote_message));
         }
 
-        let freeze_message = election::call::CallMessage::<MockContext>::FreezeElection;
+        let freeze_message = election::call::CallMessage::FreezeElection;
         messages.push((admin, freeze_message));
 
         messages

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -3,6 +3,7 @@ mod data_generation;
 mod helpers;
 mod runtime;
 mod stf;
+mod tx_hooks;
 mod tx_verifier;
 
 use data_generation::{simulate_da, QueryGenerator};
@@ -17,7 +18,7 @@ fn main() {
     let path = schemadb::temppath::TempPath::new();
     {
         let storage = ProverStorage::with_path(&path).unwrap();
-        let mut demo = Demo::<MockContext, DemoAppTxVerifier<MockContext>>::new(storage);
+        let mut demo = Demo::<MockContext, _, _>::new(storage);
         demo.init_chain(());
         demo.begin_slot();
 
@@ -55,7 +56,7 @@ mod test {
         let path = schemadb::temppath::TempPath::new();
         {
             let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo = Demo::<MockContext, DemoAppTxVerifier<MockContext>>::new(storage);
+            let mut demo = Demo::<MockContext, _, _>::new(storage);
             demo.init_chain(());
             demo.begin_slot();
 
@@ -87,7 +88,7 @@ mod test {
     #[test]
     fn test_demo_values_in_cache() {
         let storage = ProverStorage::temporary();
-        let mut demo = Demo::<MockContext, DemoAppTxVerifier<MockContext>>::new(storage.clone());
+        let mut demo = Demo::<MockContext, _, _>::new(storage.clone());
         demo.init_chain(());
         demo.begin_slot();
 
@@ -115,7 +116,7 @@ mod test {
         let path = schemadb::temppath::TempPath::new();
         {
             let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo = Demo::<MockContext, DemoAppTxVerifier<MockContext>>::new(storage);
+            let mut demo = Demo::<MockContext, _, _>::new(storage);
             demo.init_chain(());
             demo.begin_slot();
 

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let path = schemadb::temppath::TempPath::new();
     {
         let storage = ProverStorage::with_path(&path).unwrap();
-        let mut demo = Demo::<MockContext, _, _>::new(storage);
+        let mut demo = Demo::<MockContext, _>::new(storage);
         demo.init_chain(());
         demo.begin_slot();
 
@@ -55,7 +55,7 @@ mod test {
         let path = schemadb::temppath::TempPath::new();
         {
             let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo = Demo::<MockContext, _, _>::new(storage);
+            let mut demo = Demo::<MockContext, _>::new(storage);
             demo.init_chain(());
             demo.begin_slot();
 
@@ -87,7 +87,7 @@ mod test {
     #[test]
     fn test_demo_values_in_cache() {
         let storage = ProverStorage::temporary();
-        let mut demo = Demo::<MockContext, _, _>::new(storage.clone());
+        let mut demo = Demo::<MockContext, _>::new(storage.clone());
         demo.init_chain(());
         demo.begin_slot();
 
@@ -115,7 +115,7 @@ mod test {
         let path = schemadb::temppath::TempPath::new();
         {
             let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo = Demo::<MockContext, _, _>::new(storage);
+            let mut demo = Demo::<MockContext, _>::new(storage);
             demo.init_chain(());
             demo.begin_slot();
 

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -12,7 +12,6 @@ use sov_modules_api::mocks::MockContext;
 use sov_state::ProverStorage;
 use sovereign_sdk::stf::StateTransitionFunction;
 use stf::Demo;
-use tx_verifier::DemoAppTxVerifier;
 
 fn main() {
     let path = schemadb::temppath::TempPath::new();

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -14,28 +14,25 @@ use sovereign_sdk::{
     stf::{ConsensusSetUpdate, OpaqueAddress, StateTransitionFunction},
 };
 
-pub(crate) struct Demo<C: Context, V: TxVerifier, H: TxHooks> {
+pub(crate) struct Demo<C: Context, V: TxVerifier> {
     pub current_storage: C::Storage,
     pub verifier: V,
-    pub tx_hooks: H,
     pub working_set: RefCell<Option<WorkingSet<C::Storage>>>,
 }
 
-impl<C: Context> Demo<C, DemoAppTxVerifier<C>, DemoAppTxHooks<C>> {
+impl<C: Context> Demo<C, DemoAppTxVerifier<C>> {
     pub fn new(storage: C::Storage) -> Self {
         Self {
             current_storage: storage,
             verifier: DemoAppTxVerifier::new(),
-            tx_hooks: DemoAppTxHooks::new(),
             working_set: RefCell::new(None),
         }
     }
 }
 
-impl<C: Context, V, H> StateTransitionFunction for Demo<C, V, H>
+impl<C: Context, V> StateTransitionFunction for Demo<C, V>
 where
     V: TxVerifier<Context = C>,
-    H: TxHooks<Context = C>,
 {
     type StateRoot = jmt::RootHash;
 
@@ -78,20 +75,20 @@ where
             .or(Err(ConsensusSetUpdate::slashing(sequencer)))?;
         let mut batch_workspace = WorkingSet::new(self.current_storage.clone());
 
+        let mut tx_hooks = DemoAppTxHooks::<C>::new(batch_workspace.clone());
+
         for tx in txs {
             batch_workspace.to_revertable();
             // Run the stateful verification, possibly modifies the state.
-            let verified_tx = self
-                .tx_hooks
-                .pre_dispatch_tx_hook(tx, batch_workspace.clone())
+            let verified_tx = tx_hooks
+                .pre_dispatch_tx_hook(tx)
                 .or(Err(ConsensusSetUpdate::slashing(sequencer)))?;
 
             if let Ok(msg) = Runtime::<C>::decode_call(&verified_tx.runtime_msg) {
                 let ctx = C::new(verified_tx.sender);
                 let tx_result = msg.dispatch_call(batch_workspace.clone(), &ctx);
 
-                self.tx_hooks
-                    .post_dispatch_tx_hook(verified_tx, batch_workspace.clone());
+                tx_hooks.post_dispatch_tx_hook(verified_tx);
 
                 match tx_result {
                     Ok(resp) => {

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -6,6 +6,7 @@ use crate::tx_verifier::{DemoAppTxVerifier, RawTx, TxVerifier};
 
 use sov_modules_api::{Context, DispatchCall, Genesis};
 
+use crate::tx_hooks::{DemoAppTxHooks, TxHooks};
 use sov_state::{Storage, WorkingSet};
 use sovereign_sdk::{
     core::{mocks::MockProof, traits::BatchTrait},
@@ -13,25 +14,28 @@ use sovereign_sdk::{
     stf::{ConsensusSetUpdate, OpaqueAddress, StateTransitionFunction},
 };
 
-pub(crate) struct Demo<C: Context, V: TxVerifier> {
+pub(crate) struct Demo<C: Context, V: TxVerifier, H: TxHooks> {
     pub current_storage: C::Storage,
     pub verifier: V,
+    pub tx_hooks: H,
     pub working_set: RefCell<Option<WorkingSet<C::Storage>>>,
 }
 
-impl<C: Context> Demo<C, DemoAppTxVerifier<C>> {
+impl<C: Context> Demo<C, DemoAppTxVerifier<C>, DemoAppTxHooks<C>> {
     pub fn new(storage: C::Storage) -> Self {
         Self {
             current_storage: storage,
             verifier: DemoAppTxVerifier::new(),
+            tx_hooks: DemoAppTxHooks::new(),
             working_set: RefCell::new(None),
         }
     }
 }
 
-impl<C: Context, V> StateTransitionFunction for Demo<C, V>
+impl<C: Context, V, H> StateTransitionFunction for Demo<C, V, H>
 where
     V: TxVerifier<Context = C>,
+    H: TxHooks<Context = C>,
 {
     type StateRoot = jmt::RootHash;
 

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -90,6 +90,9 @@ where
                 let ctx = C::new(verified_tx.sender);
                 let tx_result = msg.dispatch_call(batch_workspace.clone(), &ctx);
 
+                self.tx_hooks
+                    .post_dispatch_tx_hook(verified_tx, batch_workspace.clone());
+
                 match tx_result {
                     Ok(resp) => {
                         events.push(resp.events);

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -82,8 +82,8 @@ where
             batch_workspace.to_revertable();
             // Run the stateful verification, possibly modifies the state.
             let verified_tx = self
-                .verifier
-                .verify_tx_stateful(tx, batch_workspace.clone())
+                .tx_hooks
+                .pre_dispatch_tx_hook(tx, batch_workspace.clone())
                 .or(Err(ConsensusSetUpdate::slashing(sequencer)))?;
 
             if let Ok(msg) = Runtime::<C>::decode_call(&verified_tx.runtime_msg) {

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -35,7 +35,7 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         &mut self,
         tx: Transaction<Self::Context>,
     ) -> anyhow::Result<VerifiedTx<Self::Context>> {
-        let addr = self.accounts_hook(tx.nonce, tx.pub_key.clone())?;
+        let addr = self.check_nonce_for_address(tx.nonce, tx.pub_key.clone())?;
 
         Ok(VerifiedTx {
             pub_key: tx.pub_key,
@@ -54,7 +54,7 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
 }
 
 impl<C: Context> DemoAppTxHooks<C> {
-    fn accounts_hook(
+    fn check_nonce_for_address(
         &mut self,
         tx_nonce: u64,
         tx_pub_key: C::PublicKey,

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -10,11 +10,11 @@ pub(crate) trait TxHooks {
         &self,
         tx: Transaction<Self::Context>,
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<VerifiedTx<Self::Context>>;
+    ) -> anyhow::Result<VerifiedTx>;
 
     fn post_dispatch_tx_hook(
         &self,
-        tx: VerifiedTx<Self::Context>,
+        tx: VerifiedTx,
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
     );
 }
@@ -38,15 +38,14 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         &self,
         tx: Transaction<Self::Context>,
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<VerifiedTx<Self::Context>> {
+    ) -> anyhow::Result<VerifiedTx> {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);
         let acc = acc_hooks.get_account_or_create_default(tx.pub_key.clone())?;
 
         anyhow::ensure!(tx.nonce == acc.nonce, "");
 
         Ok(VerifiedTx {
-            sender: tx.pub_key,
-            sender_address: acc.addr,
+            sender: acc.addr,
             runtime_msg: tx.runtime_msg,
             nonce: tx.nonce,
         })
@@ -54,7 +53,7 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
 
     fn post_dispatch_tx_hook(
         &self,
-        tx: VerifiedTx<Self::Context>,
+        _tx: VerifiedTx,
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
     ) {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -3,6 +3,7 @@ use sov_modules_api::{Context, Spec};
 use sov_state::WorkingSet;
 use std::marker::PhantomData;
 
+///
 pub(crate) trait TxHooks {
     type Context: Context;
 
@@ -42,13 +43,17 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);
         let acc = acc_hooks.get_or_create_default_account(tx.pub_key.clone())?;
 
-        anyhow::ensure!(tx.nonce == acc.nonce, "Bad nonce");
+        let tx_nonce = tx.nonce;
+        let acc_nonce = acc.nonce;
+        anyhow::ensure!(
+            acc_nonce == tx_nonce,
+            "Tx bad nonce, expected: {acc_nonce}, but found: {tx_nonce}",
+        );
 
         Ok(VerifiedTx {
             pub_key: tx.pub_key,
             sender: acc.addr,
             runtime_msg: tx.runtime_msg,
-            nonce: tx.nonce,
         })
     }
 
@@ -58,6 +63,11 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
     ) {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);
-        acc_hooks.inc_nonce(&tx.pub_key);
+
+        acc_hooks
+            .inc_nonce(&tx.pub_key)
+            // At this point we are sure, that the account corresponding to the tx.pub_key is in the db,
+            // therefore this panic should never happen, we add it for sanity check.
+            .unwrap_or_else(|e| panic!("Inconsistent nonce {e}"));
     }
 }

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -46,6 +46,7 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
 
         Ok(VerifiedTx {
             sender: tx.pub_key,
+            sender_address: acc.addr,
             runtime_msg: tx.runtime_msg,
             nonce: tx.nonce,
         })

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -40,7 +40,7 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         working_set: WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<VerifiedTx<Self::Context>> {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);
-        let acc = acc_hooks.get_account_or_create_default(tx.pub_key.clone())?;
+        let acc = acc_hooks.get_or_create_default_account(tx.pub_key.clone())?;
 
         anyhow::ensure!(tx.nonce == acc.nonce, "Bad nonce");
 
@@ -59,7 +59,5 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
     ) {
         let mut acc_hooks = accounts::hooks::Hooks::<Self::Context>::new(working_set);
         acc_hooks.inc_nonce(&tx.pub_key);
-
-        println!("Inc nonce");
     }
 }

--- a/demo-app/src/tx_hooks.rs
+++ b/demo-app/src/tx_hooks.rs
@@ -1,0 +1,54 @@
+use crate::tx_verifier::{Transaction, VerifiedTx};
+use sov_modules_api::{Context, Spec};
+use sov_state::WorkingSet;
+use std::marker::PhantomData;
+
+pub(crate) trait TxHooks {
+    type Context: Context;
+
+    fn pre_dispatch_tx_hook(
+        &self,
+        tx: Transaction<Self::Context>,
+        _storage: WorkingSet<<Self::Context as Spec>::Storage>,
+        working_set: WorkingSet<<Self::Context as Spec>::Storage>,
+    ) -> anyhow::Result<VerifiedTx<Self::Context>>;
+
+    fn post_dispatch_tx_hook(
+        &self,
+        tx: VerifiedTx<Self::Context>,
+        working_set: WorkingSet<<Self::Context as Spec>::Storage>,
+    );
+}
+
+pub(crate) struct DemoAppTxHooks<C: Context> {
+    _p: PhantomData<C>,
+}
+
+impl<C: Context> DemoAppTxHooks<C> {
+    pub fn new() -> Self {
+        Self {
+            _p: Default::default(),
+        }
+    }
+}
+
+impl<C: Context> TxHooks for DemoAppTxHooks<C> {
+    type Context = C;
+
+    fn pre_dispatch_tx_hook(
+        &self,
+        tx: Transaction<Self::Context>,
+        _storage: WorkingSet<<Self::Context as Spec>::Storage>,
+        working_set: WorkingSet<<Self::Context as Spec>::Storage>,
+    ) -> anyhow::Result<VerifiedTx<Self::Context>> {
+        todo!()
+    }
+
+    fn post_dispatch_tx_hook(
+        &self,
+        tx: VerifiedTx<Self::Context>,
+        working_set: WorkingSet<<Self::Context as Spec>::Storage>,
+    ) {
+        todo!()
+    }
+}

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_modules_api::{Context, Signature, Spec};
+use sov_modules_api::{Address, Context, Signature, Spec};
 use sov_state::WorkingSet;
 use sovereign_sdk::jmt::SimpleHasher;
 use sovereign_sdk::serial::Decode;
@@ -23,7 +23,7 @@ pub struct Transaction<C: sov_modules_api::Context> {
 /// VerifiedTx is a Transaction after verification.
 pub(crate) struct VerifiedTx<C: Context> {
     pub(crate) sender: C::PublicKey,
-    // TODO add Address
+    pub(crate) sender_address: Address,
     pub(crate) runtime_msg: Vec<u8>,
     pub(crate) nonce: u64,
 }

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -1,6 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::{Address, Context, Signature};
-use sov_state::WorkingSet;
 use sovereign_sdk::jmt::SimpleHasher;
 use sovereign_sdk::serial::Decode;
 use std::{io::Cursor, marker::PhantomData};

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -21,9 +21,8 @@ pub struct Transaction<C: sov_modules_api::Context> {
 }
 
 /// VerifiedTx is a Transaction after verification.
-pub(crate) struct VerifiedTx<C: Context> {
-    pub(crate) sender: C::PublicKey,
-    pub(crate) sender_address: Address,
+pub(crate) struct VerifiedTx {
+    pub(crate) sender: Address,
     pub(crate) runtime_msg: Vec<u8>,
     pub(crate) nonce: u64,
 }

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -25,7 +25,7 @@ pub(crate) struct VerifiedTx<C: Context> {
     pub(crate) sender: C::PublicKey,
     // TODO add Address
     pub(crate) runtime_msg: Vec<u8>,
-    pub(crate) _nonce: u64,
+    pub(crate) nonce: u64,
 }
 
 /// TxVerifier encapsulates Transaction verification.
@@ -48,13 +48,6 @@ pub(crate) trait TxVerifier {
 
         Ok(txs)
     }
-
-    /// Runs stateful checks against a Transaction. This method can modify the storage.
-    fn verify_tx_stateful(
-        &self,
-        tx: Transaction<Self::Context>,
-        storage: WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<VerifiedTx<Self::Context>>;
 }
 
 pub(crate) struct DemoAppTxVerifier<C: Context> {
@@ -85,19 +78,5 @@ impl<C: Context> TxVerifier for DemoAppTxVerifier<C> {
         tx.signature.verify(&tx.pub_key, msg_hash)?;
 
         Ok(tx)
-    }
-
-    fn verify_tx_stateful(
-        &self,
-        tx: Transaction<Self::Context>,
-        _storage: WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<VerifiedTx<Self::Context>> {
-        // TODO add stateful checks: account existence, nonce, etc..
-
-        Ok(VerifiedTx {
-            sender: tx.pub_key,
-            runtime_msg: tx.runtime_msg,
-            _nonce: tx.nonce,
-        })
     }
 }

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_modules_api::{Address, Context, Signature, Spec};
+use sov_modules_api::{Address, Context, Signature};
 use sov_state::WorkingSet;
 use sovereign_sdk::jmt::SimpleHasher;
 use sovereign_sdk::serial::Decode;
@@ -21,7 +21,8 @@ pub struct Transaction<C: sov_modules_api::Context> {
 }
 
 /// VerifiedTx is a Transaction after verification.
-pub(crate) struct VerifiedTx {
+pub(crate) struct VerifiedTx<C: Context> {
+    pub(crate) pub_key: C::PublicKey,
     pub(crate) sender: Address,
     pub(crate) runtime_msg: Vec<u8>,
     pub(crate) nonce: u64,

--- a/demo-app/src/tx_verifier.rs
+++ b/demo-app/src/tx_verifier.rs
@@ -24,7 +24,6 @@ pub(crate) struct VerifiedTx<C: Context> {
     pub(crate) pub_key: C::PublicKey,
     pub(crate) sender: Address,
     pub(crate) runtime_msg: Vec<u8>,
-    pub(crate) nonce: u64,
 }
 
 /// TxVerifier encapsulates Transaction verification.

--- a/sov-modules/sov-modules-api/Cargo.toml
+++ b/sov-modules/sov-modules-api/Cargo.toml
@@ -12,5 +12,6 @@ thiserror = { workspace = true }
 jmt = { workspace = true }
 sha2 = { workspace = true }
 
+
 [features]
 mocks = ["sov-state/mocks"]

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -37,14 +37,8 @@ impl Address {
 }
 
 impl Address {
-    pub fn new(addr: [u8; 32]) -> Self {
+    pub const fn new(addr: [u8; 32]) -> Self {
         Self { addr }
-    }
-}
-
-impl From<&'static str> for Address {
-    fn from(value: &'static str) -> Self {
-        Address::new(sha2::Sha256::hash(value.as_bytes()))
     }
 }
 

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -95,10 +95,10 @@ pub trait Spec {
 /// Context contains functionality common for all modules.
 pub trait Context: Spec + Clone + Debug + PartialEq {
     /// Sender of the transaction.
-    fn sender(&self) -> &Self::PublicKey;
+    fn sender(&self) -> Address;
 
     /// Constructor for the Context.
-    fn new(sender: Self::PublicKey) -> Self;
+    fn new(sender: Address) -> Self;
 }
 
 /// Every module has to implement this trait.

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -42,6 +42,12 @@ impl Address {
     }
 }
 
+impl From<&'static str> for Address {
+    fn from(value: &'static str) -> Self {
+        Address::new(sha2::Sha256::hash(value.as_bytes()))
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum SigVerificationError {
     #[error("Bad signature")]

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -132,8 +132,3 @@ impl Context for ZkMockContext {
         Self { sender }
     }
 }
-impl From<&'static str> for Address {
-    fn from(value: &'static str) -> Self {
-        Address::new(sha2::Sha256::hash(value.as_bytes()))
-    }
-}

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -62,7 +62,7 @@ impl Signature for MockSignature {
 /// Mock for Context, useful for testing.
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockContext {
-    pub sender: MockPublicKey,
+    pub sender: Address,
 }
 
 impl Spec for MockContext {
@@ -74,11 +74,11 @@ impl Spec for MockContext {
 }
 
 impl Context for MockContext {
-    fn sender(&self) -> &Self::PublicKey {
-        &self.sender
+    fn sender(&self) -> Address {
+        self.sender
     }
 
-    fn new(sender: Self::PublicKey) -> Self {
+    fn new(sender: Address) -> Self {
         Self { sender }
     }
 }
@@ -112,7 +112,7 @@ impl Witness for ArrrayWitness {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ZkMockContext {
-    pub sender: MockPublicKey,
+    pub sender: Address,
 }
 
 impl Spec for ZkMockContext {
@@ -124,11 +124,16 @@ impl Spec for ZkMockContext {
 }
 
 impl Context for ZkMockContext {
-    fn sender(&self) -> &Self::PublicKey {
-        &self.sender
+    fn sender(&self) -> Address {
+        self.sender
     }
 
-    fn new(sender: Self::PublicKey) -> Self {
+    fn new(sender: Address) -> Self {
         Self { sender }
+    }
+}
+impl From<&'static str> for Address {
+    fn from(value: &'static str) -> Self {
+        Address::new(sha2::Sha256::hash(value.as_bytes()))
     }
 }

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -9,33 +9,12 @@ pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub enum CallMessage<C: sov_modules_api::Context> {
-    // Creates a new account.
-    CreateAccount,
     // Updates a PublicKey for the corresponding Account.
     // The sender must be in possession of the new PublicKey.
     UpdatePublicKey(C::PublicKey, C::Signature),
 }
 
 impl<C: sov_modules_api::Context> Accounts<C> {
-    pub(crate) fn create_account(&mut self, context: &C) -> Result<CallResponse> {
-        self.exit_if_account_exists(context.sender())?;
-
-        let default_address = context.sender().to_address();
-        self.exit_if_address_exists(&default_address)?;
-
-        let new_account = Account {
-            addr: default_address,
-            nonce: 0,
-        };
-
-        self.accounts.set(context.sender(), new_account);
-
-        self.public_keys
-            .set(&default_address, context.sender().clone());
-
-        Ok(CallResponse::default())
-    }
-
     pub(crate) fn update_public_key(
         &mut self,
         new_pub_key: C::PublicKey,

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -1,9 +1,8 @@
-use crate::Account;
 use crate::Accounts;
 use anyhow::{ensure, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
+use sov_modules_api::CallResponse;
 use sov_modules_api::Signature;
-use sov_modules_api::{Address, CallResponse, PublicKey};
 
 pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 

--- a/sov-modules/sov-modules-impl/accounts/src/hooks.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/hooks.rs
@@ -35,7 +35,13 @@ impl<C: Context> Hooks<C> {
         }
     }
 
-    pub fn inc_nonce(&mut self, address: &Address) {}
+    pub fn inc_nonce(&mut self, pub_key: &C::PublicKey) -> Result<()> {
+        let mut account = self.inner.accounts.get_or_err(pub_key)?;
+        account.nonce += 1;
+        self.inner.accounts.set(pub_key, account);
+
+        Ok(())
+    }
 
     fn exit_if_address_exists(&self, address: &Address) -> Result<()> {
         anyhow::ensure!(

--- a/sov-modules/sov-modules-impl/accounts/src/hooks.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/hooks.rs
@@ -1,0 +1,47 @@
+use crate::{Account, Accounts, Address};
+use anyhow::Result;
+use sov_modules_api::ModuleInfo;
+use sov_modules_api::PublicKey;
+use sov_modules_api::{Context, Spec};
+use sov_state::WorkingSet;
+
+pub struct Hooks<C: sov_modules_api::Context> {
+    inner: Accounts<C>,
+}
+
+impl<C: Context> Hooks<C> {
+    pub fn new(storage: WorkingSet<C::Storage>) -> Self {
+        Self {
+            inner: Accounts::new(storage),
+        }
+    }
+
+    pub fn get_account_or_create_default(&mut self, pub_key: C::PublicKey) -> Result<Account> {
+        match self.inner.accounts.get(&pub_key) {
+            Some(acc) => return Ok(acc),
+            None => {
+                let default_address = pub_key.to_address();
+                self.exit_if_address_exists(&default_address)?;
+                let new_account = Account {
+                    addr: default_address,
+                    nonce: 0,
+                };
+
+                self.inner.accounts.set(&pub_key, new_account.clone());
+                self.inner.public_keys.set(&default_address, pub_key);
+
+                Ok(new_account)
+            }
+        }
+    }
+
+    pub fn inc_nonce(&mut self, address: &Address) {}
+
+    fn exit_if_address_exists(&self, address: &Address) -> Result<()> {
+        anyhow::ensure!(
+            self.inner.public_keys.get(address).is_none(),
+            "Address already exists"
+        );
+        Ok(())
+    }
+}

--- a/sov-modules/sov-modules-impl/accounts/src/hooks.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/hooks.rs
@@ -1,8 +1,8 @@
 use crate::{Account, Accounts, Address};
 use anyhow::Result;
+use sov_modules_api::Context;
 use sov_modules_api::ModuleInfo;
 use sov_modules_api::PublicKey;
-use sov_modules_api::{Context, Spec};
 use sov_state::WorkingSet;
 
 pub struct Hooks<C: sov_modules_api::Context> {
@@ -16,20 +16,20 @@ impl<C: Context> Hooks<C> {
         }
     }
 
-    pub fn get_account_or_create_default(&mut self, pub_key: C::PublicKey) -> Result<Account> {
+    pub fn get_or_create_default_account(&mut self, pub_key: C::PublicKey) -> Result<Account> {
         match self.inner.accounts.get(&pub_key) {
-            Some(acc) => return Ok(acc),
+            Some(acc) => Ok(acc),
             None => {
                 let default_address = pub_key.to_address();
                 self.exit_if_address_exists(&default_address)?;
+
                 let new_account = Account {
                     addr: default_address,
                     nonce: 0,
                 };
 
-                self.inner.accounts.set(&pub_key, new_account.clone());
+                self.inner.accounts.set(&pub_key, new_account);
                 self.inner.public_keys.set(&default_address, pub_key);
-
                 Ok(new_account)
             }
         }

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod hooks;
+
 mod call;
 mod genesis;
 mod query;
@@ -9,7 +11,7 @@ use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq, Copy, Clone)]
-struct Account {
+pub struct Account {
     pub addr: Address,
     pub nonce: u64,
 }

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -42,7 +42,6 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
         context: &Self::Context,
     ) -> Result<sov_modules_api::CallResponse, Error> {
         match msg {
-            call::CallMessage::CreateAccount => Ok(self.create_account(context)?),
             call::CallMessage::UpdatePublicKey(new_pub_key, sig) => {
                 Ok(self.update_public_key(new_pub_key, sig, context)?)
             }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -23,7 +23,7 @@ fn test_update_account() {
 
     // Test new account creation
     {
-        hooks.get_account_or_create_default(sender.clone()).unwrap();
+        hooks.get_or_create_default_account(sender.clone()).unwrap();
 
         let query_response: query::Response = serde_json::from_slice(
             &accounts
@@ -85,13 +85,13 @@ fn test_update_account_fails() {
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
     let sender_context_1 = C::new(sender_1.to_address());
-    hooks.get_account_or_create_default(sender_1).unwrap();
+    hooks.get_or_create_default_account(sender_1).unwrap();
 
     let sender_2 = MockPublicKey::try_from("pub_key_2").unwrap();
     let sig_2 = sender_2.sign(call::UPDATE_ACCOUNT_MSG);
 
     hooks
-        .get_account_or_create_default(sender_2.clone())
+        .get_or_create_default_account(sender_2.clone())
         .unwrap();
 
     // The new public key already exists and the call fails.
@@ -112,13 +112,13 @@ fn test_create_account_fails() {
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
     let sender_context_1 = C::new(sender_1.to_address());
 
-    hooks.get_account_or_create_default(sender_1).unwrap();
+    hooks.get_or_create_default_account(sender_1).unwrap();
 
     let new_pub_key = MockPublicKey::try_from("pub_key_2").unwrap();
     let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
     accounts
         .call(
-            call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
+            call::CallMessage::<C>::UpdatePublicKey(new_pub_key, sig),
             &sender_context_1,
         )
         .unwrap();

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    call,
+    call, hooks,
     query::{self, QueryMessage},
     Accounts,
 };
@@ -14,7 +14,8 @@ type C = MockContext;
 #[test]
 fn test_update_account() {
     let native_storage = WorkingSet::new(ProverStorage::temporary());
-    let accounts = &mut Accounts::<C>::new(native_storage);
+    let accounts = &mut Accounts::<C>::new(native_storage.clone());
+    let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender = MockPublicKey::try_from("pub_key").unwrap();
     let sender_addr: Address = sender.to_address();
@@ -22,9 +23,7 @@ fn test_update_account() {
 
     // Test new account creation
     {
-        accounts
-            .call(call::CallMessage::<C>::CreateAccount, &sender_context)
-            .unwrap();
+        hooks.get_account_or_create_default(sender.clone()).unwrap();
 
         let query_response: query::Response = serde_json::from_slice(
             &accounts
@@ -81,21 +80,18 @@ fn test_update_account() {
 #[test]
 fn test_update_account_fails() {
     let native_storage = WorkingSet::new(ProverStorage::temporary());
-    let accounts = &mut Accounts::<C>::new(native_storage);
+    let accounts = &mut Accounts::<C>::new(native_storage.clone());
+    let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
-    let sender_context_1 = C::new(sender_1);
-
-    accounts
-        .call(call::CallMessage::<C>::CreateAccount, &sender_context_1)
-        .unwrap();
+    let sender_context_1 = C::new(sender_1.clone());
+    hooks.get_account_or_create_default(sender_1).unwrap();
 
     let sender_2 = MockPublicKey::try_from("pub_key_2").unwrap();
     let sig_2 = sender_2.sign(call::UPDATE_ACCOUNT_MSG);
-    let sender_context_2 = C::new(sender_2.clone());
 
-    accounts
-        .call(call::CallMessage::<C>::CreateAccount, &sender_context_2)
+    hooks
+        .get_account_or_create_default(sender_2.clone())
         .unwrap();
 
     // The new public key already exists and the call fails.
@@ -110,14 +106,13 @@ fn test_update_account_fails() {
 #[test]
 fn test_create_account_fails() {
     let native_storage = WorkingSet::new(ProverStorage::temporary());
-    let accounts = &mut Accounts::<C>::new(native_storage);
+    let accounts = &mut Accounts::<C>::new(native_storage.clone());
+    let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
-    let sender_context_1 = C::new(sender_1);
+    let sender_context_1 = C::new(sender_1.clone());
 
-    accounts
-        .call(call::CallMessage::<C>::CreateAccount, &sender_context_1)
-        .unwrap();
+    hooks.get_account_or_create_default(sender_1).unwrap();
 
     let new_pub_key = MockPublicKey::try_from("pub_key_2").unwrap();
     let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
@@ -128,10 +123,6 @@ fn test_create_account_fails() {
         )
         .unwrap();
 
-    let sender_context_2 = C::new(new_pub_key);
-
     // Account creation fails because the `new_pub_key` is already registered.
-    assert!(accounts
-        .call(call::CallMessage::<C>::CreateAccount, &sender_context_2)
-        .is_err())
+    // assert!(hooks.get_account_or_create_default(new_pub_key).is_err());
 }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -104,13 +104,14 @@ fn test_update_account_fails() {
 }
 
 #[test]
-fn test_create_account_fails() {
+fn test_get_acc_after_pub_key_update() {
     let native_storage = WorkingSet::new(ProverStorage::temporary());
     let accounts = &mut Accounts::<C>::new(native_storage.clone());
     let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
-    let sender_context_1 = C::new(sender_1.to_address());
+    let sender_1_addr = sender_1.to_address();
+    let sender_context_1 = C::new(sender_1_addr);
 
     hooks.get_or_create_default_account(sender_1).unwrap();
 
@@ -118,11 +119,11 @@ fn test_create_account_fails() {
     let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
     accounts
         .call(
-            call::CallMessage::<C>::UpdatePublicKey(new_pub_key, sig),
+            call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
             &sender_context_1,
         )
         .unwrap();
 
-    // Account creation fails because the `new_pub_key` is already registered.
-    // assert!(hooks.get_account_or_create_default(new_pub_key).is_err());
+    let acc = hooks.get_or_create_default_account(new_pub_key).unwrap();
+    assert_eq!(acc.addr, sender_1_addr)
 }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -19,7 +19,7 @@ fn test_update_account() {
 
     let sender = MockPublicKey::try_from("pub_key").unwrap();
     let sender_addr: Address = sender.to_address();
-    let sender_context = C::new(sender.clone());
+    let sender_context = C::new(sender_addr);
 
     // Test new account creation
     {
@@ -84,7 +84,7 @@ fn test_update_account_fails() {
     let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
-    let sender_context_1 = C::new(sender_1.clone());
+    let sender_context_1 = C::new(sender_1.to_address());
     hooks.get_account_or_create_default(sender_1).unwrap();
 
     let sender_2 = MockPublicKey::try_from("pub_key_2").unwrap();
@@ -110,7 +110,7 @@ fn test_create_account_fails() {
     let mut hooks = hooks::Hooks::<C>::new(native_storage);
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
-    let sender_context_1 = C::new(sender_1.clone());
+    let sender_context_1 = C::new(sender_1.to_address());
 
     hooks.get_account_or_create_default(sender_1).unwrap();
 

--- a/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
@@ -1,9 +1,13 @@
-use super::{Election, ADMIN};
-use anyhow::Result;
+use super::Election;
+use anyhow::{anyhow, Result};
+use sov_modules_api::PublicKey;
 
 impl<C: sov_modules_api::Context> Election<C> {
     pub(crate) fn init_module(&mut self) -> Result<()> {
-        self.admin.set(ADMIN);
+        let admin_pub_key = C::PublicKey::try_from("election_admin")
+            .map_err(|_| anyhow!("Admin initialization failed"))?;
+
+        self.admin.set(admin_pub_key.to_address());
         self.is_frozen.set(false);
         Ok(())
     }

--- a/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
@@ -1,12 +1,9 @@
-use super::Election;
-use anyhow::{anyhow, Result};
+use super::{Election, ADMIN};
+use anyhow::Result;
 
 impl<C: sov_modules_api::Context> Election<C> {
     pub(crate) fn init_module(&mut self) -> Result<()> {
-        let admin =
-            C::PublicKey::try_from("admin").map_err(|_| anyhow!("Admin initialization failed"))?;
-
-        self.admin.set(admin);
+        self.admin.set(ADMIN);
         self.is_frozen.set(false);
         Ok(())
     }

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -13,12 +13,6 @@ use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 use types::Voter;
 
-//TODO https://github.com/Sovereign-Labs/sovereign/issues/134
-pub(crate) const ADMIN: Address = Address::new([
-    140, 105, 118, 229, 181, 65, 4, 21, 189, 233, 8, 189, 77, 238, 21, 223, 177, 103, 169, 200,
-    115, 252, 75, 184, 168, 31, 111, 42, 180, 72, 169, 24,
-]);
-
 #[derive(ModuleInfo)]
 pub struct Election<C: sov_modules_api::Context> {
     #[state]

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -9,14 +9,16 @@ mod types;
 
 pub use types::Candidate;
 
-use sov_modules_api::Error;
+use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 use types::Voter;
+
+pub(crate) const ADMIN: Address = Address::new([7; 32]);
 
 #[derive(ModuleInfo)]
 pub struct Election<C: sov_modules_api::Context> {
     #[state]
-    pub(crate) admin: sov_state::StateValue<C::PublicKey, C::Storage>,
+    pub(crate) admin: sov_state::StateValue<Address, C::Storage>,
 
     #[state]
     pub(crate) is_frozen: sov_state::StateValue<bool, C::Storage>,
@@ -32,13 +34,13 @@ pub struct Election<C: sov_modules_api::Context> {
     pub(crate) candidates: sov_state::StateValue<Vec<Candidate>, C::Storage>,
 
     #[state]
-    pub(crate) allowed_voters: sov_state::StateMap<C::PublicKey, Voter, C::Storage>,
+    pub(crate) allowed_voters: sov_state::StateMap<Address, Voter, C::Storage>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
     type Context = C;
 
-    type CallMessage = call::CallMessage<C>;
+    type CallMessage = call::CallMessage;
 
     type QueryMessage = query::QueryMessage;
 
@@ -54,8 +56,8 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
         match msg {
             Self::CallMessage::SetCandidates { names } => Ok(self.set_candidates(names, context)?),
 
-            Self::CallMessage::AddVoter(voter_pub_key) => {
-                Ok(self.add_voter(voter_pub_key, context)?)
+            Self::CallMessage::AddVoter(voter_address) => {
+                Ok(self.add_voter(voter_address, context)?)
             }
 
             Self::CallMessage::Vote(candidate_index) => {

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -13,7 +13,11 @@ use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 use types::Voter;
 
-pub(crate) const ADMIN: Address = Address::new([7; 32]);
+//TODO https://github.com/Sovereign-Labs/sovereign/issues/134
+pub(crate) const ADMIN: Address = Address::new([
+    140, 105, 118, 229, 181, 65, 4, 21, 189, 233, 8, 189, 77, 238, 21, 223, 177, 103, 169, 200,
+    115, 252, 75, 184, 168, 31, 111, 42, 180, 72, 169, 24,
+]);
 
 #[derive(ModuleInfo)]
 pub struct Election<C: sov_modules_api::Context> {

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     Election,
 };
 
-use crate::ADMIN;
+use anyhow::anyhow;
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey, ZkMockContext},
     Context, Module, ModuleInfo, PublicKey,
@@ -26,7 +26,8 @@ fn test_election() {
 
 fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Storage>) {
     let admin_pub_key = C::PublicKey::try_from("election_admin")
-        .map_err(|_| anyhow!("Admin initialization failed"))?;
+        .map_err(|_| anyhow!("Admin initialization failed"))
+        .unwrap();
 
     let admin_context = C::new(admin_pub_key.to_address());
     let election = &mut Election::<C>::new(storage);

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -25,7 +25,10 @@ fn test_election() {
 }
 
 fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Storage>) {
-    let admin_context = C::new(ADMIN);
+    let admin_pub_key = C::PublicKey::try_from("election_admin")
+        .map_err(|_| anyhow!("Admin initialization failed"))?;
+
+    let admin_context = C::new(admin_pub_key.to_address());
     let election = &mut Election::<C>::new(storage);
 
     // Init module

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -26,11 +26,11 @@ fn test_election() {
 
 fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Storage>) {
     let admin_context = C::new(ADMIN);
-    let ellection = &mut Election::<C>::new(storage);
+    let election = &mut Election::<C>::new(storage);
 
     // Init module
     {
-        ellection.genesis().unwrap();
+        election.genesis().unwrap();
     }
 
     // Send candidates
@@ -39,7 +39,7 @@ fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Sto
             names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
         };
 
-        ellection.call(set_candidates, &admin_context).unwrap();
+        election.call(set_candidates, &admin_context).unwrap();
     }
 
     let voter_1 = MockPublicKey::try_from("voter_1").unwrap().to_address();
@@ -49,38 +49,38 @@ fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Sto
     // Register voters
     {
         let add_voter = CallMessage::AddVoter(voter_1);
-        ellection.call(add_voter, &admin_context).unwrap();
+        election.call(add_voter, &admin_context).unwrap();
 
         let add_voter = CallMessage::AddVoter(voter_2);
-        ellection.call(add_voter, &admin_context).unwrap();
+        election.call(add_voter, &admin_context).unwrap();
 
         let add_voter = CallMessage::AddVoter(voter_3);
-        ellection.call(add_voter, &admin_context).unwrap();
+        election.call(add_voter, &admin_context).unwrap();
     }
 
     // Vote
     {
         let sender_context = C::new(voter_1);
         let vote = CallMessage::Vote(0);
-        ellection.call(vote, &sender_context).unwrap();
+        election.call(vote, &sender_context).unwrap();
 
         let sender_context = C::new(voter_2);
         let vote = CallMessage::Vote(1);
-        ellection.call(vote, &sender_context).unwrap();
+        election.call(vote, &sender_context).unwrap();
 
         let sender_context = C::new(voter_3);
         let vote = CallMessage::Vote(1);
-        ellection.call(vote, &sender_context).unwrap();
+        election.call(vote, &sender_context).unwrap();
     }
 
-    ellection
+    election
         .call(CallMessage::FreezeElection, &admin_context)
         .unwrap();
 
     // Get result
     {
         let query = QueryMessage::GetResult;
-        let query = ellection.query(query);
+        let query = election.query(query);
         let query_response: Response = serde_json::from_slice(&query.response).unwrap();
 
         assert_eq!(

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -5,9 +5,10 @@ use super::{
     Election,
 };
 
+use crate::ADMIN;
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey, ZkMockContext},
-    Context, Module, ModuleInfo,
+    Context, Module, ModuleInfo, PublicKey,
 };
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 
@@ -24,8 +25,7 @@ fn test_election() {
 }
 
 fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Storage>) {
-    let admin = MockPublicKey::try_from("admin").unwrap();
-    let admin_context = C::new(admin);
+    let admin_context = C::new(ADMIN);
     let ellection = &mut Election::<C>::new(storage);
 
     // Init module
@@ -42,19 +42,19 @@ fn test_module<C: Context<PublicKey = MockPublicKey>>(storage: WorkingSet<C::Sto
         ellection.call(set_candidates, &admin_context).unwrap();
     }
 
-    let voter_1 = MockPublicKey::try_from("voter_1").unwrap();
-    let voter_2 = MockPublicKey::try_from("voter_2").unwrap();
-    let voter_3 = MockPublicKey::try_from("voter_3").unwrap();
+    let voter_1 = MockPublicKey::try_from("voter_1").unwrap().to_address();
+    let voter_2 = MockPublicKey::try_from("voter_2").unwrap().to_address();
+    let voter_3 = MockPublicKey::try_from("voter_3").unwrap().to_address();
 
     // Register voters
     {
-        let add_voter = CallMessage::AddVoter(voter_1.clone());
+        let add_voter = CallMessage::AddVoter(voter_1);
         ellection.call(add_voter, &admin_context).unwrap();
 
-        let add_voter = CallMessage::AddVoter(voter_2.clone());
+        let add_voter = CallMessage::AddVoter(voter_2);
         ellection.call(add_voter, &admin_context).unwrap();
 
-        let add_voter = CallMessage::AddVoter(voter_3.clone());
+        let add_voter = CallMessage::AddVoter(voter_3);
         ellection.call(add_voter, &admin_context).unwrap();
     }
 

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/call.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/call.rs
@@ -33,7 +33,7 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
 
         let admin = self.admin.get_or_err()?;
 
-        if &admin != context.sender() {
+        if admin != context.sender() {
             // Here we use a custom error type.
             Err(SetValueError::WrongSender)?;
         }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -1,12 +1,11 @@
 use super::ValueSetter;
+use super::ADMIN;
 use anyhow::Result;
-use sov_modules_api::Address;
 
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
     pub(crate) fn init_module(&mut self) -> Result<()> {
-        let admin: Address = Address::from("admin");
-        self.admin.set(admin);
+        self.admin.set(ADMIN);
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -1,11 +1,14 @@
 use super::ValueSetter;
-use super::ADMIN;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use sov_modules_api::PublicKey;
 
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
     pub(crate) fn init_module(&mut self) -> Result<()> {
-        self.admin.set(ADMIN);
+        let admin_pub_key = C::PublicKey::try_from("value_setter_admin")
+            .map_err(|_| anyhow!("Admin initialization failed"))?;
+
+        self.admin.set(admin_pub_key.to_address());
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -1,16 +1,11 @@
 use super::ValueSetter;
-use anyhow::{bail, Result};
+use anyhow::Result;
+use sov_modules_api::Address;
 
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
     pub(crate) fn init_module(&mut self) -> Result<()> {
-        let maybe_admin = C::PublicKey::try_from("admin");
-
-        let admin = match maybe_admin {
-            Ok(admin) => admin,
-            Err(_) => bail!("Admin initialization failed"),
-        };
-
+        let admin: Address = Address::from("admin");
         self.admin.set(admin);
         Ok(())
     }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -11,7 +11,7 @@ pub mod query;
 use self::query::QueryMessage;
 
 use self::call::CallMessage;
-use sov_modules_api::Error;
+use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
 #[derive(ModuleInfo)]
@@ -20,7 +20,7 @@ pub struct ValueSetter<C: sov_modules_api::Context> {
     pub value: sov_state::StateValue<u32, C::Storage>,
 
     #[state]
-    pub admin: sov_state::StateValue<C::PublicKey, C::Storage>,
+    pub admin: sov_state::StateValue<Address, C::Storage>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueSetter<C> {

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -14,12 +14,6 @@ use self::call::CallMessage;
 use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
-//TODO https://github.com/Sovereign-Labs/sovereign/issues/134
-pub(crate) const ADMIN: Address = Address::new([
-    140, 105, 118, 229, 181, 65, 4, 21, 189, 233, 8, 189, 77, 238, 21, 223, 177, 103, 169, 200,
-    115, 252, 75, 184, 168, 31, 111, 42, 180, 72, 169, 24,
-]);
-
 #[derive(ModuleInfo)]
 pub struct ValueSetter<C: sov_modules_api::Context> {
     #[state]

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -15,7 +15,10 @@ use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
 //TODO https://github.com/Sovereign-Labs/sovereign/issues/134
-pub(crate) const ADMIN: Address = Address::new([7; 32]);
+pub(crate) const ADMIN: Address = Address::new([
+    140, 105, 118, 229, 181, 65, 4, 21, 189, 233, 8, 189, 77, 238, 21, 223, 177, 103, 169, 200,
+    115, 252, 75, 184, 168, 31, 111, 42, 180, 72, 169, 24,
+]);
 
 #[derive(ModuleInfo)]
 pub struct ValueSetter<C: sov_modules_api::Context> {

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -14,6 +14,9 @@ use self::call::CallMessage;
 use sov_modules_api::{Address, Error};
 use sov_modules_macros::ModuleInfo;
 
+//TODO https://github.com/Sovereign-Labs/sovereign/issues/134
+pub(crate) const ADMIN: Address = Address::new([7; 32]);
+
 #[derive(ModuleInfo)]
 pub struct ValueSetter<C: sov_modules_api::Context> {
     #[state]

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -1,16 +1,16 @@
 use super::ValueSetter;
 use crate::{call, query};
 
+use sov_modules_api::mocks::MockContext;
 use sov_modules_api::mocks::ZkMockContext;
-use sov_modules_api::mocks::{MockContext, MockPublicKey};
-use sov_modules_api::Context;
+use sov_modules_api::{Address, Context};
 use sov_modules_api::{Module, ModuleInfo};
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
-    let sender = MockPublicKey::try_from("admin").unwrap();
+    let sender = Address::from("admin");
     let storage = WorkingSet::new(ProverStorage::temporary());
 
     // Test Native-Context
@@ -60,13 +60,13 @@ fn test_value_setter_helper<C: Context>(context: C, storage: WorkingSet<C::Stora
 
 #[test]
 fn test_err_on_sender_is_not_admin() {
-    let sender = MockPublicKey::try_from("not_admin").unwrap();
+    let sender = Address::from("not_admin");
     let backing_store = ProverStorage::temporary();
     let native_tx_store = WorkingSet::new(backing_store);
 
     // Test Native-Context
     {
-        let context = MockContext::new(sender.clone());
+        let context = MockContext::new(sender);
         test_err_on_sender_is_not_admin_helper(context, native_tx_store.clone());
     }
     let (_, witness) = native_tx_store.freeze();

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -1,16 +1,22 @@
 use super::ValueSetter;
-use crate::{call, query, ADMIN};
+use crate::{call, query};
 
-use sov_modules_api::mocks::MockContext;
-use sov_modules_api::mocks::ZkMockContext;
-use sov_modules_api::{Address, Context};
+use anyhow::anyhow;
+use sov_modules_api::{
+    mocks::{MockContext, MockPublicKey, ZkMockContext},
+    Address, Context, PublicKey,
+};
 use sov_modules_api::{Module, ModuleInfo};
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
-    let sender = ADMIN;
+    let admin_pub_key = MockPublicKey::try_from("value_setter_admin")
+        .map_err(|_| anyhow!("Admin initialization failed"))
+        .unwrap();
+
+    let sender = admin_pub_key.to_address();
     let storage = WorkingSet::new(ProverStorage::temporary());
 
     // Test Native-Context

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -1,5 +1,5 @@
 use super::ValueSetter;
-use crate::{call, query};
+use crate::{call, query, ADMIN};
 
 use sov_modules_api::mocks::MockContext;
 use sov_modules_api::mocks::ZkMockContext;
@@ -10,7 +10,7 @@ use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
-    let sender = Address::from("admin");
+    let sender = ADMIN;
     let storage = WorkingSet::new(ProverStorage::temporary());
 
     // Test Native-Context
@@ -60,7 +60,7 @@ fn test_value_setter_helper<C: Context>(context: C, storage: WorkingSet<C::Stora
 
 #[test]
 fn test_err_on_sender_is_not_admin() {
-    let sender = Address::from("not_admin");
+    let sender = Address::new([9; 32]);
     let backing_store = ProverStorage::temporary();
     let native_tx_store = WorkingSet::new(backing_store);
 

--- a/sov-modules/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/sov-modules/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -2,10 +2,7 @@ mod modules;
 
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::ModuleInfo;
-use sov_modules_api::{
-    mocks::{MockContext, MockPublicKey},
-    Context, Genesis, Module,
-};
+use sov_modules_api::{mocks::MockContext, Address, Context, Genesis, Module};
 use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 use sov_state::ProverStorage;
 
@@ -22,7 +19,7 @@ fn main() {
     let storage = ProverStorage::temporary();
     let working_set = sov_state::WorkingSet::new(storage);
     RT::genesis(working_set.clone()).unwrap();
-    let context = MockContext::new(MockPublicKey::new(vec![]));
+    let context = MockContext::new(Address::new([0; 32]));
 
     let value = 11;
     {


### PR DESCRIPTION
This PR introduces the following changes:
1. Integrates `Accounts` module with `DemoApp`
2. Changes `Context::sender` type from `PublicKey` to `Address` + updates all relevant unit tests
3. Introduces `TxHooks` trait. `TxHooks` allows injecting custom logic into a transaction processing pipeline. For example,
now we have a way to update a nonce after a tx is processed