### PR TITLE
Remove Rc & RefCell from WorkingSet

### DIFF
--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -78,7 +78,7 @@ where
         let mut tx_hooks = DemoAppTxHooks::<C>::new();
 
         for tx in txs {
-            batch_workspace.to_revertable();
+            batch_workspace = batch_workspace.to_revertable();
             // Run the stateful verification, possibly modifies the state.
             let verified_tx = tx_hooks
                 .pre_dispatch_tx_hook(tx, &mut batch_workspace)
@@ -93,7 +93,7 @@ where
                 match tx_result {
                     Ok(resp) => {
                         events.push(resp.events);
-                        batch_workspace.commit();
+                        batch_workspace = batch_workspace.commit();
                     }
                     Err(e) => {
                         // Don't merge the tx workspace. TODO add tests for this scenario

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -65,12 +65,12 @@ fn test_value_setter_helper<C: Context>(context: C, working_set: &mut WorkingSet
 fn test_err_on_sender_is_not_admin() {
     let sender = Address::new([9; 32]);
     let backing_store = ProverStorage::temporary();
-    let native_working_set = WorkingSet::new(backing_store);
+    let native_working_set = &mut WorkingSet::new(backing_store);
 
     // Test Native-Context
     {
         let context = MockContext::new(sender);
-        test_err_on_sender_is_not_admin_helper(context, native_working_set.clone());
+        test_err_on_sender_is_not_admin_helper(context, native_working_set);
     }
     let (_, witness) = native_working_set.freeze();
 
@@ -78,18 +78,18 @@ fn test_err_on_sender_is_not_admin() {
     {
         let zk_backing_store = ZkStorage::new([0u8; 32]);
         let zk_context = ZkMockContext::new(sender);
-        let zk_working_set = WorkingSet::with_witness(zk_backing_store, witness);
+        let zk_working_set = &mut WorkingSet::with_witness(zk_backing_store, witness);
         test_err_on_sender_is_not_admin_helper(zk_context, zk_working_set);
     }
 }
 
 fn test_err_on_sender_is_not_admin_helper<C: Context>(
     context: C,
-    mut working_set: WorkingSet<C::Storage>,
+    working_set: &mut WorkingSet<C::Storage>,
 ) {
     let mut module = ValueSetter::<C>::new();
-    module.genesis(&mut working_set).unwrap();
-    let resp = module.set_value(11, &context, &mut working_set);
+    module.genesis(working_set).unwrap();
+    let resp = module.set_value(11, &context, working_set);
 
     assert!(resp.is_err());
 }

--- a/sov-modules/sov-state/src/scratchpad.rs
+++ b/sov-modules/sov-state/src/scratchpad.rs
@@ -231,7 +231,6 @@ impl<S: Storage> Delta<S> {
     }
 
     fn get_with_witness(&mut self, key: StorageKey, witness: &S::Witness) -> Option<StorageValue> {
-        // self.cache.get_or_fetch(key, &self.inner, witness)
         self.cache.get_or_fetch(key, &self.inner, witness)
     }
 }

--- a/sov-modules/sov-state/src/scratchpad.rs
+++ b/sov-modules/sov-state/src/scratchpad.rs
@@ -51,7 +51,7 @@ impl<S: Storage> WorkingSet<S> {
 
     pub fn to_revertable(self) -> WorkingSet<S> {
         match self {
-            WorkingSet::Standard(delta) => WorkingSet::Revertable(get_revertable_wrapper(delta)),
+            WorkingSet::Standard(delta) => WorkingSet::Revertable(delta.get_revertable_wrapper()),
             r @ WorkingSet::Revertable(_) => r,
         }
     }
@@ -153,21 +153,6 @@ impl<S: Storage> RevertableDelta<S> {
     }
 }
 
-fn get_revertable_wrapper<S: Storage>(delta: Delta<S>) -> RevertableDelta<S> {
-    get_revertable_wrapper_with_witness(delta, Default::default())
-}
-
-fn get_revertable_wrapper_with_witness<S: Storage>(
-    delta: Delta<S>,
-    witness: S::Witness,
-) -> RevertableDelta<S> {
-    RevertableDelta {
-        inner: delta,
-        witness,
-        cache: Default::default(),
-    }
-}
-
 impl<S: Storage> Delta<S> {
     fn new(inner: S) -> Self {
         Self {
@@ -180,6 +165,18 @@ impl<S: Storage> Delta<S> {
     fn with_witness(inner: S, witness: S::Witness) -> Self {
         Self {
             inner,
+            witness,
+            cache: Default::default(),
+        }
+    }
+
+    fn get_revertable_wrapper(self) -> RevertableDelta<S> {
+        self.get_revertable_wrapper_with_witness(Default::default())
+    }
+
+    fn get_revertable_wrapper_with_witness(self, witness: S::Witness) -> RevertableDelta<S> {
+        RevertableDelta {
+            inner: self,
             witness,
             cache: Default::default(),
         }

--- a/sov-modules/sov-state/src/scratchpad.rs
+++ b/sov-modules/sov-state/src/scratchpad.rs
@@ -128,24 +128,24 @@ impl<S: Storage> RevertableDelta<S> {
 }
 
 impl<S: Storage> RevertableDelta<S> {
-    fn commit(mut self) -> Delta<S> {
+    fn commit(self) -> Delta<S> {
         let mut inner = self.inner;
 
         inner
             .cache
-            .merge_left(std::mem::take(&mut self.cache))
+            .merge_left(self.cache)
             .expect("caches must be consistent");
 
         inner.witness.merge(&self.witness);
         inner
     }
 
-    fn revert(mut self) -> Delta<S> {
+    fn revert(self) -> Delta<S> {
         let mut inner = self.inner;
 
         inner
             .cache
-            .merge_reads_left(std::mem::take(&mut self.cache))
+            .merge_reads_left(self.cache)
             .expect("caches must be consistent");
 
         inner.witness.merge(&self.witness);

--- a/sov-modules/sov-state/src/state_tests.rs
+++ b/sov-modules/sov-state/src/state_tests.rs
@@ -13,8 +13,8 @@ impl Operation {
         match self {
             Operation::Merge => working_set.commit(),
             Operation::Finalize => {
-                let db = working_set.backing();
                 let (cache_log, witness) = working_set.freeze();
+                let db = working_set.backing();
                 db.validate_and_commit(cache_log, &witness)
                     .expect("JMT update is valid");
             }
@@ -29,7 +29,7 @@ struct StorageOperation {
 impl StorageOperation {
     fn execute(&self, working_set: &mut WorkingSet<ProverStorage<MockStorageSpec>>) {
         for op in self.operations.iter() {
-            op.execute(&mut working_set.clone())
+            op.execute(working_set)
         }
     }
 }

--- a/sov-modules/sov-state/src/state_tests.rs
+++ b/sov-modules/sov-state/src/state_tests.rs
@@ -9,7 +9,10 @@ enum Operation {
 }
 
 impl Operation {
-    fn execute(&self, working_set: &mut WorkingSet<ProverStorage<MockStorageSpec>>) {
+    fn execute(
+        &self,
+        mut working_set: WorkingSet<ProverStorage<MockStorageSpec>>,
+    ) -> WorkingSet<ProverStorage<MockStorageSpec>> {
         match self {
             Operation::Merge => working_set.commit(),
             Operation::Finalize => {
@@ -17,6 +20,7 @@ impl Operation {
                 let db = working_set.backing();
                 db.validate_and_commit(cache_log, &witness)
                     .expect("JMT update is valid");
+                working_set
             }
         }
     }
@@ -27,10 +31,14 @@ struct StorageOperation {
 }
 
 impl StorageOperation {
-    fn execute(&self, working_set: &mut WorkingSet<ProverStorage<MockStorageSpec>>) {
+    fn execute(
+        &self,
+        mut working_set: WorkingSet<ProverStorage<MockStorageSpec>>,
+    ) -> WorkingSet<ProverStorage<MockStorageSpec>> {
         for op in self.operations.iter() {
-            op.execute(working_set)
+            working_set = op.execute(working_set)
         }
+        working_set
     }
 }
 
@@ -93,10 +101,10 @@ fn test_state_map() {
         let value = 11;
         let (mut state_map, mut working_set) = create_state_map_and_storage(key, value, &path);
 
-        before_remove.execute(&mut working_set);
+        working_set = before_remove.execute(working_set);
         assert_eq!(state_map.remove(&key, &mut working_set).unwrap(), value);
 
-        after_remove.execute(&mut working_set);
+        working_set = after_remove.execute(working_set);
         assert!(state_map.get(&key, &mut working_set).is_none())
     }
 }
@@ -122,10 +130,10 @@ fn test_state_value() {
         let value = 11;
         let (mut state_value, mut working_set) = create_state_value_and_storage(value, &path);
 
-        before_remove.execute(&mut working_set);
+        working_set = before_remove.execute(working_set);
         assert_eq!(state_value.remove(&mut working_set).unwrap(), value);
 
-        after_remove.execute(&mut working_set);
+        working_set = after_remove.execute(working_set);
         assert!(state_value.get(&mut working_set).is_none())
     }
 }


### PR DESCRIPTION
Overview: 
The following commits remove `Rc<RefCell<_>>` from the `WorkingSet`
[e5f0209](https://github.com/Sovereign-Labs/sovereign/pull/142/commits/e5f020925154dc17b5b623d00e2c7dee37b79d76)
[56d913c](https://github.com/Sovereign-Labs/sovereign/pull/142/commits/56d913c24015cc2470a3da5a87dbcf7583c8ae38)
[93d96ce](https://github.com/Sovereign-Labs/sovereign/pull/142/commits/93d96ce3907a79a04d208b4f164d4f4e2d48a727)

Unfortunately, we still have to wrap `Delta` in`Option` inside `WorkingSet` to satisfy the borrow checker (we can't use `mem::take` because Storage doesn't have a default implementation).

[011ec9c](https://github.com/Sovereign-Labs/sovereign/pull/142/commits/011ec9cd8d5164c5e3105873ea995f7537cecb79)

Introduces "consuming API" for `to_revertable, commit, revert`. This allows removing the redundant `Options` but impacts how `WorkingSet` is used.  I am slightly in favor of the consuming API.  

