### PR TITLE
Extract `Runtime` from `Demo`

### DIFF
--- a/demo-app/src/helpers.rs
+++ b/demo-app/src/helpers.rs
@@ -5,12 +5,13 @@ use std::str;
 use crate::runtime::Runtime;
 
 pub(crate) fn check_query(
+    runtime: &mut Runtime<MockContext>,
     query: Vec<u8>,
     expected_response: &str,
     storage: ProverStorage<MockStorageSpec>,
 ) {
     let module = Runtime::<MockContext>::decode_query(&query).unwrap();
-    let query_response = module.dispatch_query(&mut WorkingSet::new(storage));
+    let query_response = runtime.dispatch_query(module, &mut WorkingSet::new(storage));
 
     let response = str::from_utf8(&query_response.response).unwrap();
     assert_eq!(response, expected_response)

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -7,21 +7,37 @@ mod stf;
 mod tx_hooks;
 mod tx_verifier;
 
+use std::path::Path;
+
 use data_generation::{simulate_da, QueryGenerator};
 use helpers::check_query;
 use runtime::Runtime;
 use sov_modules_api::mocks::MockContext;
-use sov_state::ProverStorage;
+use sov_state::{mocks::MockStorageSpec, ProverStorage};
 use sovereign_sdk::stf::StateTransitionFunction;
 use stf::Demo;
+use tx_hooks::DemoAppTxHooks;
 use tx_verifier::DemoAppTxVerifier;
+
+type C = MockContext;
+type DemoApp = Demo<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>>;
+
+fn create_new_demo(path: impl AsRef<Path>) -> (DemoApp, ProverStorage<MockStorageSpec>) {
+    let runtime = Runtime::new();
+    let storage = ProverStorage::with_path(path).unwrap();
+    let tx_hooks = DemoAppTxHooks::new();
+    let tx_verifier = DemoAppTxVerifier::new();
+
+    (
+        Demo::new(storage.clone(), runtime, tx_verifier, tx_hooks),
+        storage,
+    )
+}
 
 fn main() {
     let path = schemadb::temppath::TempPath::new();
     {
-        let runtime = Runtime::<MockContext>::new();
-        let storage = ProverStorage::with_path(&path).unwrap();
-        let mut demo = Demo::<MockContext, _, _>::new(storage, runtime, DemoAppTxVerifier::new());
+        let (mut demo, _) = create_new_demo(&path);
         demo.init_chain(());
         demo.begin_slot();
 
@@ -61,10 +77,8 @@ mod test {
     fn test_demo_values_in_db() {
         let path = schemadb::temppath::TempPath::new();
         {
-            let runtime = Runtime::<MockContext>::new();
-            let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo =
-                Demo::<MockContext, _, _>::new(storage, runtime, DemoAppTxVerifier::new());
+            let (mut demo, _) = create_new_demo(&path);
+
             demo.init_chain(());
             demo.begin_slot();
 
@@ -98,10 +112,9 @@ mod test {
 
     #[test]
     fn test_demo_values_in_cache() {
-        let runtime = Runtime::<MockContext>::new();
-        let storage = ProverStorage::temporary();
-        let mut demo =
-            Demo::<MockContext, _, _>::new(storage.clone(), runtime, DemoAppTxVerifier::new());
+        let path = schemadb::temppath::TempPath::new();
+        let (mut demo, storage) = create_new_demo(&path);
+
         demo.init_chain(());
         demo.begin_slot();
 
@@ -131,10 +144,8 @@ mod test {
     fn test_demo_values_not_in_db() {
         let path = schemadb::temppath::TempPath::new();
         {
-            let runtime = Runtime::<MockContext>::new();
-            let storage = ProverStorage::with_path(&path).unwrap();
-            let mut demo =
-                Demo::<MockContext, _, _>::new(storage, runtime, DemoAppTxVerifier::new());
+            let (mut demo, _) = create_new_demo(&path);
+
             demo.init_chain(());
             demo.begin_slot();
 
@@ -146,7 +157,7 @@ mod test {
 
         // Generate a new storage instance, value are missing because we didn't call `end_slot()`;
         {
-            let runtime = &mut Runtime::<MockContext>::new();
+            let runtime = &mut Runtime::<C>::new();
             let storage = ProverStorage::with_path(&path).unwrap();
             check_query(
                 runtime,

--- a/demo-app/src/runtime.rs
+++ b/demo-app/src/runtime.rs
@@ -50,7 +50,7 @@ pub(crate) struct Runtime<C: Context> {
     accounts: accounts::Accounts<C>,
 }
 
-// TODO add macro to generate the code below.
+// TODO add macro to generate the following code.
 impl<C: Context> Runtime<C> {
     pub(crate) fn new() -> Self {
         Self {

--- a/demo-app/src/runtime.rs
+++ b/demo-app/src/runtime.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::{Context, Module};
+use sov_modules_api::{Context, Module, ModuleInfo};
 use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 
 /// On a high level, the rollup node receives serialized call messages from the DA layer and executes them as atomic transactions.
@@ -37,6 +37,8 @@ use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 ///
 /// Similar mechanism works for queries with the difference that queries are submitted by users directly to the rollup node
 /// instead of going through the DA layer.
+//#[derive(Genesis, DispatchCall2, DispatchQuery, MessageCodec)]
+//#[derive(DispatchCall2, Genesis, DispatchQuery, MessageCodec)]
 #[derive(Genesis, DispatchCall, DispatchQuery, MessageCodec)]
 pub(crate) struct Runtime<C: Context> {
     /// Definition of the first module in the rollup (must implement the sov_modules_api::Module trait).
@@ -45,4 +47,18 @@ pub(crate) struct Runtime<C: Context> {
     // Definition of the second module in the rollup (must implement the sov_modules_api::Module trait).
     #[allow(unused)]
     value_setter: value_setter::ValueSetter<C>,
+
+    #[allow(unused)]
+    accounts: accounts::Accounts<C>,
+}
+
+// TODO add macro to generate the code below.
+impl<C: Context> Runtime<C> {
+    pub(crate) fn new() -> Self {
+        Self {
+            election: election::Election::new(),
+            value_setter: value_setter::ValueSetter::new(),
+            accounts: accounts::Accounts::new(),
+        }
+    }
 }

--- a/demo-app/src/runtime.rs
+++ b/demo-app/src/runtime.rs
@@ -37,8 +37,6 @@ use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 ///
 /// Similar mechanism works for queries with the difference that queries are submitted by users directly to the rollup node
 /// instead of going through the DA layer.
-//#[derive(Genesis, DispatchCall2, DispatchQuery, MessageCodec)]
-//#[derive(DispatchCall2, Genesis, DispatchQuery, MessageCodec)]
 #[derive(Genesis, DispatchCall, DispatchQuery, MessageCodec)]
 pub(crate) struct Runtime<C: Context> {
     /// Definition of the first module in the rollup (must implement the sov_modules_api::Module trait).

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -11,7 +11,7 @@ use sovereign_sdk::{
 };
 
 pub(crate) struct Demo<C: Context, V, RT, H> {
-    current_storage: C::Storage,
+    pub(crate) current_storage: C::Storage,
     runtime: RT,
     tx_verifier: V,
     tx_hooks: H,

--- a/demo-app/src/stf.rs
+++ b/demo-app/src/stf.rs
@@ -11,15 +11,15 @@ use sovereign_sdk::{
 };
 
 pub(crate) struct Demo<C: Context, V, RT, H> {
-    pub current_storage: C::Storage,
-    pub runtime: RT,
-    pub tx_verifier: V,
-    pub tx_hooks: H,
-    pub working_set: Option<WorkingSet<C::Storage>>,
+    current_storage: C::Storage,
+    runtime: RT,
+    tx_verifier: V,
+    tx_hooks: H,
+    working_set: Option<WorkingSet<C::Storage>>,
 }
 
 impl<C: Context, V, RT, H> Demo<C, V, RT, H> {
-    pub fn new(storage: C::Storage, runtime: RT, tx_verifier: V, tx_hooks: H) -> Self {
+    pub(crate) fn new(storage: C::Storage, runtime: RT, tx_verifier: V, tx_hooks: H) -> Self {
         Self {
             runtime,
             current_storage: storage,

--- a/sov-modules/sov-modules-api/src/dispatch.rs
+++ b/sov-modules/sov-modules-api/src/dispatch.rs
@@ -17,6 +17,7 @@ pub trait DispatchCall {
     type Context: Context;
     type Decodable;
 
+    /// Decode serialized call message
     fn decode_call(serialized_message: &[u8]) -> Result<Self::Decodable, std::io::Error>;
 
     /// Dispatches a call message to the appropriate module.
@@ -36,6 +37,7 @@ pub trait DispatchQuery {
     type Context: Context;
     type Decodable;
 
+    /// Decode serialized query message
     fn decode_query(serialized_message: &[u8]) -> Result<Self::Decodable, std::io::Error>;
 
     /// Dispatches a query message to the appropriate module.

--- a/sov-modules/sov-modules-api/src/dispatch.rs
+++ b/sov-modules/sov-modules-api/src/dispatch.rs
@@ -1,6 +1,5 @@
-use sov_state::WorkingSet;
-
 use crate::{Address, CallResponse, Context, Error, QueryResponse, Spec};
+use sov_state::WorkingSet;
 
 /// Methods from this trait should be called only once during the rollup deployment.
 pub trait Genesis {
@@ -8,6 +7,7 @@ pub trait Genesis {
 
     /// Initializes the state of the rollup.
     fn genesis(
+        &mut self,
         working_set: &mut WorkingSet<<<Self as Genesis>::Context as Spec>::Storage>,
     ) -> Result<(), Error>;
 }
@@ -15,25 +15,33 @@ pub trait Genesis {
 /// A trait that needs to be implemented for any call message.
 pub trait DispatchCall {
     type Context: Context;
+    type Decodable;
+
+    fn decode_call(serialized_message: &[u8]) -> Result<Self::Decodable, std::io::Error>;
 
     /// Dispatches a call message to the appropriate module.
     fn dispatch_call(
-        self,
+        &mut self,
+        message: Self::Decodable,
         working_set: &mut WorkingSet<<<Self as DispatchCall>::Context as Spec>::Storage>,
         context: &Self::Context,
     ) -> Result<CallResponse, Error>;
 
     /// Returns an address of the dispatched module.
-    fn module_address(&self) -> Address;
+    fn module_address(&self, message: &Self::Decodable) -> Address;
 }
 
 /// A trait that needs to be implemented for any query message.
 pub trait DispatchQuery {
     type Context: Context;
+    type Decodable;
+
+    fn decode_query(serialized_message: &[u8]) -> Result<Self::Decodable, std::io::Error>;
 
     /// Dispatches a query message to the appropriate module.
     fn dispatch_query(
-        self,
+        &mut self,
+        message: Self::Decodable,
         working_set: &mut WorkingSet<<<Self as DispatchQuery>::Context as Spec>::Storage>,
     ) -> QueryResponse;
 }

--- a/sov-modules/sov-modules-macros/src/dispatch/common.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/common.rs
@@ -111,7 +111,7 @@ impl<'a> StructDef<'a> {
             // TODO we should not hardcode the serialization format inside the macro:
             // https://github.com/Sovereign-Labs/sovereign/issues/97
             #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, ::core::fmt::Debug, PartialEq)]
-            enum #enum_ident #impl_generics #where_clause {
+            pub (crate) enum #enum_ident #impl_generics #where_clause {
                 #(#enum_legs)*
             }
         }

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -25,10 +25,10 @@ impl<'a> StructDef<'a> {
 
         let match_legs = self.fields.iter().map(|field| {
             let name = &field.ident;
-            
+
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                    core::result::Result::Ok(sov_modules_api::Module::call(&mut self.#name, message, context, working_set)?)
+                    sov_modules_api::Module::call(&mut self.#name, message, context, working_set)
                 },
             )
         });
@@ -57,7 +57,7 @@ impl<'a> StructDef<'a> {
                 type Context = #generic_param;
                 type Decodable = #call_enum #ty_generics;
 
-                
+
                 fn decode_call(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
                     let mut data = std::io::Cursor::new(serialized_message);
                     core::result::Result::Ok(<#call_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -60,7 +60,7 @@ impl<'a> StructDef<'a> {
 
                 fn decode_call(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
                     let mut data = std::io::Cursor::new(serialized_message);
-                    core::result::Result::Ok(<#call_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)
+                    <#call_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)
                 }
 
                 fn dispatch_call(

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -19,19 +19,16 @@ impl<'a> StructDef<'a> {
             .collect()
     }
 
-    /// Implements `sov_modules_api::DispatchCall` for the enumeration created by `create_enum`.
     fn create_call_dispatch(&self) -> proc_macro2::TokenStream {
         let enum_ident = self.enum_ident(CALL);
         let type_generics = &self.type_generics;
 
         let match_legs = self.fields.iter().map(|field| {
             let name = &field.ident;
-            let ty = &field.ty;
-
+            
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                    let mut #name = <#ty as sov_modules_api::ModuleInfo>::new();
-                    sov_modules_api::Module::call(&mut #name, message, context, working_set)
+                    core::result::Result::Ok(sov_modules_api::Module::call(&mut self.#name, message, context, working_set)?)
                 },
             )
         });
@@ -48,31 +45,42 @@ impl<'a> StructDef<'a> {
             )
         });
 
+        let ident = &self.ident;
         let impl_generics = &self.impl_generics;
         let where_clause = self.where_clause;
         let generic_param = self.generic_param;
+        let ty_generics = &self.type_generics;
+        let call_enum = self.enum_ident(CALL);
 
         quote::quote! {
-            impl #impl_generics sov_modules_api::DispatchCall for #enum_ident #type_generics #where_clause{
+            impl #impl_generics sov_modules_api::DispatchCall for #ident #type_generics #where_clause {
                 type Context = #generic_param;
+                type Decodable = #call_enum #ty_generics;
+
+                
+                fn decode_call(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
+                    let mut data = std::io::Cursor::new(serialized_message);
+                    core::result::Result::Ok(<#call_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)
+                }
 
                 fn dispatch_call(
-                    self,
+                    &mut self,
+                    decodable: Self::Decodable,
                     working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
                     context: &Self::Context,
                 ) -> core::result::Result<sov_modules_api::CallResponse, sov_modules_api::Error> {
 
-                    match self{
+                    match decodable {
                         #(#match_legs)*
                     }
+
                 }
 
-                fn module_address(&self) -> sov_modules_api::Address {
-                    match self{
+                fn module_address(&self, decodable: &Self::Decodable) -> sov_modules_api::Address {
+                    match decodable {
                         #(#match_legs_address)*
                     }
                 }
-
             }
         }
     }

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
@@ -26,7 +26,7 @@ impl<'a> StructDef<'a> {
 
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                    sov_modules_api::Module::query(&mut self.#name, message, working_set)
+                    sov_modules_api::Module::query(&self.#name, message, working_set)
                 },
             )
         });

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
@@ -45,7 +45,7 @@ impl<'a> StructDef<'a> {
 
                 fn decode_query(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
                     let mut data = std::io::Cursor::new(serialized_message);
-                    core::result::Result::Ok(<#query_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)
+                    <#query_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)
                 }
 
                 fn dispatch_query(

--- a/sov-modules/sov-modules-macros/src/dispatch/genesis.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/genesis.rs
@@ -35,7 +35,7 @@ impl GenesisMacro {
             impl #impl_generics sov_modules_api::Genesis for #ident #type_generics #where_clause {
                 type Context = #generic_param;
 
-                fn genesis(working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
+                fn genesis(&mut self, working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
                     #(#genesis_fn_body)*
                     Ok(())
                 }
@@ -49,14 +49,9 @@ impl GenesisMacro {
             .iter()
             .map(|field| {
                 let ident = &field.ident;
-                let ty = &field.ty;
 
-                // generates body for `genesis` method:
-                //  let mut module_name = <ModuleName::<C> as sov_modules_api::ModuleInfo>::new();
-                //  module_name.genesis(working_set)?;
                 quote::quote! {
-                    let mut #ident = <#ty as sov_modules_api::ModuleInfo>::new();
-                    #ident.genesis(working_set)?;
+                    self.#ident.genesis(working_set)?;
                 }
             })
             .collect()

--- a/sov-modules/sov-modules-macros/src/dispatch/message_codec.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/message_codec.rs
@@ -41,16 +41,6 @@ impl<'a> StructDef<'a> {
         quote::quote! {
             impl #impl_generics #original_ident #ty_generics #where_clause {
                 #(#fns)*
-
-                pub (crate) fn decode_query(data: &[u8]) -> core::result::Result<impl sov_modules_api::DispatchQuery<Context = C>, anyhow::Error>{
-                    let mut data = std::io::Cursor::new(data);
-                    core::result::Result::Ok(<#query_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)
-                }
-
-                pub (crate) fn decode_call(data: &[u8]) ->  core::result::Result<impl sov_modules_api::DispatchCall<Context = C>, anyhow::Error> {
-                    let mut data = std::io::Cursor::new(data);
-                    core::result::Result::Ok(<#call_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)?)
-                }
             }
         }
     }

--- a/sov-modules/sov-modules-macros/src/lib.rs
+++ b/sov-modules/sov-modules-macros/src/lib.rs
@@ -49,7 +49,7 @@ pub fn genesis(input: TokenStream) -> TokenStream {
 
 /// Derives the `sov-modules-api::DispatchCall` implementation for the underlying type.
 #[proc_macro_derive(DispatchCall)]
-pub fn dispatch_call(input: TokenStream) -> TokenStream {
+pub fn dispatch_call2(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
     let call_macro = DispatchCallMacro::new("Call");
 

--- a/sov-modules/sov-modules-macros/src/lib.rs
+++ b/sov-modules/sov-modules-macros/src/lib.rs
@@ -49,7 +49,7 @@ pub fn genesis(input: TokenStream) -> TokenStream {
 
 /// Derives the `sov-modules-api::DispatchCall` implementation for the underlying type.
 #[proc_macro_derive(DispatchCall)]
-pub fn dispatch_call2(input: TokenStream) -> TokenStream {
+pub fn dispatch_call(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
     let call_macro = DispatchCallMacro::new("Call");
 

--- a/sov-modules/sov-modules-macros/tests/dispatch/derive_genesis.rs
+++ b/sov-modules/sov-modules-macros/tests/dispatch/derive_genesis.rs
@@ -1,12 +1,13 @@
 mod modules;
 
 use modules::{first_test_module, second_test_module};
-use sov_modules_api::{mocks::MockContext, Context, Module};
-use sov_modules_macros::{DispatchQuery, Genesis};
+use sov_modules_api::mocks::MockContext;
+use sov_modules_api::{Context, Module, ModuleInfo};
+use sov_modules_macros::{DispatchCall, DispatchQuery, Genesis, MessageCodec};
 use sov_state::ProverStorage;
 
 // Debugging hint: To expand the macro in tests run: `cargo expand --test tests`
-#[derive(Genesis, DispatchQuery)]
+#[derive(Genesis, DispatchQuery, DispatchCall, MessageCodec)]
 struct Runtime<C>
 where
     C: Context,
@@ -15,22 +16,33 @@ where
     second: second_test_module::SecondTestStruct<C>,
 }
 
+impl<C: Context> Runtime<C> {
+    fn new() -> Self {
+        Self {
+            first: first_test_module::FirstTestStruct::<C>::new(),
+            second: second_test_module::SecondTestStruct::<C>::new(),
+        }
+    }
+}
+
 fn main() {
     use sov_modules_api::{DispatchQuery, Genesis};
 
     type C = MockContext;
     let storage = ProverStorage::temporary();
     let working_set = &mut sov_state::WorkingSet::new(storage);
-    Runtime::<C>::genesis(working_set).unwrap();
+    let runtime = &mut Runtime::<C>::new();
+    runtime.genesis(working_set).unwrap();
+
     {
         let message = RuntimeQuery::<C>::first(());
-        let response = message.dispatch_query(working_set);
+        let response = runtime.dispatch_query(message, working_set);
         assert_eq!(response.response, vec![1]);
     }
 
     {
         let message = RuntimeQuery::<C>::second(second_test_module::TestType {});
-        let response = message.dispatch_query(working_set);
+        let response = runtime.dispatch_query(message, working_set);
         assert_eq!(response.response, vec![2]);
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:
1. Hardcoded `Runtime` and `TxHooks` are extracted from the `Demo`. Now `Demo` is "runtime independent" (depends only on `DispatchCall+Genesis` traits)
2.  In order to improve ergonomics and make 1 possible, `DispatchCall/Query` traits are extended with `decode_call/query` methods. Before, these methods were implemented (macro-generated) directly on the `Runtime` struct.
