### PR TITLE
Module methods accept `&self` instead of `&mut self`

### DIFF
--- a/sov-modules/sov-modules-api/src/dispatch.rs
+++ b/sov-modules/sov-modules-api/src/dispatch.rs
@@ -7,7 +7,7 @@ pub trait Genesis {
 
     /// Initializes the state of the rollup.
     fn genesis(
-        &mut self,
+        &self,
         working_set: &mut WorkingSet<<<Self as Genesis>::Context as Spec>::Storage>,
     ) -> Result<(), Error>;
 }
@@ -22,7 +22,7 @@ pub trait DispatchCall {
 
     /// Dispatches a call message to the appropriate module.
     fn dispatch_call(
-        &mut self,
+        &self,
         message: Self::Decodable,
         working_set: &mut WorkingSet<<<Self as DispatchCall>::Context as Spec>::Storage>,
         context: &Self::Context,
@@ -42,7 +42,7 @@ pub trait DispatchQuery {
 
     /// Dispatches a query message to the appropriate module.
     fn dispatch_query(
-        &mut self,
+        &self,
         message: Self::Decodable,
         working_set: &mut WorkingSet<<<Self as DispatchQuery>::Context as Spec>::Storage>,
     ) -> QueryResponse;

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -118,7 +118,7 @@ pub trait Module {
 
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(
-        &mut self,
+        &self,
         _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> Result<(), Error> {
         Ok(())
@@ -127,7 +127,7 @@ pub trait Module {
     /// Call allows interaction with the module and invokes state changes.
     /// It takes a module defined type and a context as parameters.
     fn call(
-        &mut self,
+        &self,
         _message: Self::CallMessage,
         _context: &Self::Context,
         _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,

--- a/sov-modules/sov-modules-impl/accounts/src/call.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/call.rs
@@ -16,7 +16,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 
 impl<C: sov_modules_api::Context> Accounts<C> {
     pub(crate) fn update_public_key(
-        &mut self,
+        &self,
         new_pub_key: C::PublicKey,
         signature: C::Signature,
         context: &C,

--- a/sov-modules/sov-modules-impl/accounts/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/genesis.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> Accounts<C> {
-    pub(crate) fn init_module(&mut self, _working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
+    pub(crate) fn init_module(&self, _working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
         // TODO read initial accounts from "Config"
         Ok(())
     }

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -33,12 +33,12 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
 
     type QueryMessage = query::QueryMessage<C>;
 
-    fn genesis(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
+    fn genesis(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
         Ok(self.init_module(working_set)?)
     }
 
     fn call(
-        &mut self,
+        &self,
         msg: Self::CallMessage,
         context: &Self::Context,
         working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-modules-impl/examples/election/src/call.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/call.rs
@@ -21,7 +21,7 @@ pub enum CallMessage {
 impl<C: sov_modules_api::Context> Election<C> {
     /// Sets the candidates. Must be called by the Admin.
     pub(crate) fn set_candidates(
-        &mut self,
+        &self,
         candidate_names: Vec<String>,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
@@ -38,7 +38,7 @@ impl<C: sov_modules_api::Context> Election<C> {
 
     /// Adds voter to the allow list. Must be called by the Admin.
     pub(crate) fn add_voter(
-        &mut self,
+        &self,
         voter_address: Address,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
@@ -55,7 +55,7 @@ impl<C: sov_modules_api::Context> Election<C> {
 
     /// Votes for a candidate. Must be called by the Voter.
     pub(crate) fn make_vote(
-        &mut self,
+        &self,
         // TODO the candidates are stored in `Vec` which allows iteration, but it forces us
         // to use candidate_index instead of candidate_name here. We will change it once
         // we have iterator for `StateMap`.
@@ -95,7 +95,7 @@ impl<C: sov_modules_api::Context> Election<C> {
 
     /// Freezes the election.
     pub(crate) fn freeze_election(
-        &mut self,
+        &self,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
@@ -105,7 +105,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     }
 
     /// Clears the election.
-    pub(crate) fn clear(&mut self) -> Result<CallResponse> {
+    pub(crate) fn clear(&self) -> Result<CallResponse> {
         // see https://github.com/Sovereign-Labs/sovereign/issues/62
         todo!()
     }

--- a/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
@@ -4,7 +4,7 @@ use sov_modules_api::PublicKey;
 use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> Election<C> {
-    pub(crate) fn init_module(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
+    pub(crate) fn init_module(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
         let admin_pub_key = C::PublicKey::try_from("election_admin")
             .map_err(|_| anyhow!("Admin initialization failed"))?;
 

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -43,12 +43,12 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
 
     type QueryMessage = query::QueryMessage;
 
-    fn genesis(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
+    fn genesis(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
         Ok(self.init_module(working_set)?)
     }
 
     fn call(
-        &mut self,
+        &self,
         msg: Self::CallMessage,
         context: &Self::Context,
         working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/call.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/call.rs
@@ -26,7 +26,7 @@ enum SetValueError {
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Sets `value` field to the `new_value`, only admin is authorized to call this method.
     pub(crate) fn set_value(
-        &mut self,
+        &self,
         new_value: u32,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -5,7 +5,7 @@ use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
-    pub(crate) fn init_module(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
+    pub(crate) fn init_module(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
         let admin_pub_key = C::PublicKey::try_from("value_setter_admin")
             .map_err(|_| anyhow!("Admin initialization failed"))?;
 

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -32,12 +32,12 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueSetter<C> {
     #[cfg(feature = "native")]
     type QueryMessage = QueryMessage;
 
-    fn genesis(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
+    fn genesis(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
         Ok(self.init_module(working_set)?)
     }
 
     fn call(
-        &mut self,
+        &self,
         msg: Self::CallMessage,
         context: &Self::Context,
         working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -32,7 +32,7 @@ fn test_value_setter() {
 }
 
 fn test_value_setter_helper<C: Context>(context: C, working_set: &mut WorkingSet<C::Storage>) {
-    let mut module = ValueSetter::<C>::new();
+    let module = ValueSetter::<C>::new();
     module.genesis(working_set).unwrap();
 
     let new_value = 99;
@@ -87,7 +87,7 @@ fn test_err_on_sender_is_not_admin_helper<C: Context>(
     context: C,
     working_set: &mut WorkingSet<C::Storage>,
 ) {
-    let mut module = ValueSetter::<C>::new();
+    let module = ValueSetter::<C>::new();
     module.genesis(working_set).unwrap();
     let resp = module.set_value(11, &context, working_set);
 

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -28,7 +28,7 @@ impl<'a> StructDef<'a> {
 
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                    sov_modules_api::Module::call(&mut self.#name, message, context, working_set)
+                    sov_modules_api::Module::call(&self.#name, message, context, working_set)
                 },
             )
         });
@@ -64,7 +64,7 @@ impl<'a> StructDef<'a> {
                 }
 
                 fn dispatch_call(
-                    &mut self,
+                    &self,
                     decodable: Self::Decodable,
                     working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
                     context: &Self::Context,

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
@@ -49,7 +49,7 @@ impl<'a> StructDef<'a> {
                 }
 
                 fn dispatch_query(
-                    &mut self,
+                    &self,
                     decodable: Self::Decodable,
                     working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>
                 ) -> sov_modules_api::QueryResponse {

--- a/sov-modules/sov-modules-macros/src/dispatch/genesis.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/genesis.rs
@@ -35,7 +35,7 @@ impl GenesisMacro {
             impl #impl_generics sov_modules_api::Genesis for #ident #type_generics #where_clause {
                 type Context = #generic_param;
 
-                fn genesis(&mut self, working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
+                fn genesis(&self, working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
                     #(#genesis_fn_body)*
                     Ok(())
                 }

--- a/sov-modules/sov-modules-macros/tests/dispatch/modules.rs
+++ b/sov-modules/sov-modules-macros/tests/dispatch/modules.rs
@@ -16,13 +16,13 @@ pub mod first_test_module {
         type CallMessage = u8;
         type QueryMessage = ();
 
-        fn genesis(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
+        fn genesis(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
             self.state_in_first_struct.set(1, working_set);
             Ok(())
         }
 
         fn call(
-            &mut self,
+            &self,
             msg: Self::CallMessage,
             _context: &Self::Context,
             working_set: &mut WorkingSet<C::Storage>,
@@ -61,13 +61,13 @@ pub mod second_test_module {
         type CallMessage = u8;
         type QueryMessage = TestType;
 
-        fn genesis(&mut self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
+        fn genesis(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<(), Error> {
             self.state_in_second_struct.set(2, working_set);
             Ok(())
         }
 
         fn call(
-            &mut self,
+            &self,
             msg: Self::CallMessage,
             _context: &Self::Context,
             working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-state/src/map.rs
+++ b/sov-modules/sov-state/src/map.rs
@@ -27,7 +27,7 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     }
 
     /// Inserts a key-value pair into the map.
-    pub fn set(&mut self, key: &K, value: V, working_set: &mut WorkingSet<S>) {
+    pub fn set(&self, key: &K, value: V, working_set: &mut WorkingSet<S>) {
         working_set.set_value(self.prefix(), key, value)
     }
 
@@ -44,19 +44,19 @@ impl<K: Encode, V: Encode + Decode, S: Storage> StateMap<K, V, S> {
     }
 
     /// Removes a key from the StateMap, returning the corresponding value (or None if the key is absent).
-    pub fn remove(&mut self, key: &K, working_set: &mut WorkingSet<S>) -> Option<V> {
+    pub fn remove(&self, key: &K, working_set: &mut WorkingSet<S>) -> Option<V> {
         working_set.remove_value(self.prefix(), key)
     }
 
     /// Removes a key from the StateMap, returning the corresponding value (or Error if the key is absent).
-    pub fn remove_or_err(&mut self, key: &K, working_set: &mut WorkingSet<S>) -> Result<V, Error> {
+    pub fn remove_or_err(&self, key: &K, working_set: &mut WorkingSet<S>) -> Result<V, Error> {
         self.remove(key, working_set).ok_or_else(|| {
             Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), key))
         })
     }
 
     /// Deletes a key from the StateMap.
-    pub fn delete(&mut self, key: &K, working_set: &mut WorkingSet<S>) {
+    pub fn delete(&self, key: &K, working_set: &mut WorkingSet<S>) {
         working_set.delete_value(self.prefix(), key);
     }
 

--- a/sov-modules/sov-state/src/state_tests.rs
+++ b/sov-modules/sov-state/src/state_tests.rs
@@ -88,7 +88,7 @@ fn create_state_map_and_storage(
 ) {
     let mut working_set = WorkingSet::new(ProverStorage::with_path(&path).unwrap());
 
-    let mut state_map = StateMap::new(Prefix::new(vec![0]));
+    let state_map = StateMap::new(Prefix::new(vec![0]));
     state_map.set(&key, value, &mut working_set);
     (state_map, working_set)
 }
@@ -99,7 +99,7 @@ fn test_state_map_with_remove() {
     for (before_remove, after_remove) in create_storage_operations() {
         let key = 1;
         let value = 11;
-        let (mut state_map, mut working_set) = create_state_map_and_storage(key, value, &path);
+        let (state_map, mut working_set) = create_state_map_and_storage(key, value, &path);
 
         working_set = before_remove.execute(working_set);
         assert_eq!(state_map.remove(&key, &mut working_set).unwrap(), value);
@@ -115,7 +115,7 @@ fn test_state_map_with_delete() {
     for (before_delete, after_delete) in create_storage_operations() {
         let key = 1;
         let value = 11;
-        let (mut state_map, mut working_set) = create_state_map_and_storage(key, value, &path);
+        let (state_map, mut working_set) = create_state_map_and_storage(key, value, &path);
 
         working_set = before_delete.execute(working_set);
         state_map.delete(&key, &mut working_set);
@@ -134,7 +134,7 @@ fn create_state_value_and_storage(
 ) {
     let mut working_set = WorkingSet::new(ProverStorage::with_path(&path).unwrap());
 
-    let mut state_value = StateValue::new(Prefix::new(vec![0]));
+    let state_value = StateValue::new(Prefix::new(vec![0]));
     state_value.set(value, &mut working_set);
     (state_value, working_set)
 }
@@ -144,7 +144,7 @@ fn test_state_value_with_remove() {
     let path = schemadb::temppath::TempPath::new();
     for (before_remove, after_remove) in create_storage_operations() {
         let value = 11;
-        let (mut state_value, mut working_set) = create_state_value_and_storage(value, &path);
+        let (state_value, mut working_set) = create_state_value_and_storage(value, &path);
 
         working_set = before_remove.execute(working_set);
         assert_eq!(state_value.remove(&mut working_set).unwrap(), value);
@@ -159,7 +159,7 @@ fn test_state_value_with_delete() {
     let path = schemadb::temppath::TempPath::new();
     for (before_delete, after_delete) in create_storage_operations() {
         let value = 11;
-        let (mut state_value, mut working_set) = create_state_value_and_storage(value, &path);
+        let (state_value, mut working_set) = create_state_value_and_storage(value, &path);
 
         working_set = before_delete.execute(working_set);
         state_value.delete(&mut working_set);

--- a/sov-modules/sov-state/src/value.rs
+++ b/sov-modules/sov-state/src/value.rs
@@ -39,7 +39,7 @@ impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
     }
 
     /// Sets a value in the StateValue.
-    pub fn set(&mut self, value: V, working_set: &mut WorkingSet<S>) {
+    pub fn set(&self, value: V, working_set: &mut WorkingSet<S>) {
         working_set.set_value(self.prefix(), &SingletonKey, value)
     }
 
@@ -55,18 +55,18 @@ impl<V: Encode + Decode, S: Storage> StateValue<V, S> {
     }
 
     /// Removes a value from the StateValue, returning the value (or None if the key is absent).
-    pub fn remove(&mut self, working_set: &mut WorkingSet<S>) -> Option<V> {
+    pub fn remove(&self, working_set: &mut WorkingSet<S>) -> Option<V> {
         working_set.remove_value(self.prefix(), &SingletonKey)
     }
 
     /// Removes a value and from the StateValue, returning the value (or Error if the key is absent).
-    pub fn remove_or_err(&mut self, working_set: &mut WorkingSet<S>) -> Result<V, Error> {
+    pub fn remove_or_err(&self, working_set: &mut WorkingSet<S>) -> Result<V, Error> {
         self.remove(working_set)
             .ok_or_else(|| Error::MissingValue(self.prefix().clone()))
     }
 
     /// Deletes a value from the StateValue.
-    pub fn delete(&mut self, working_set: &mut WorkingSet<S>) {
+    pub fn delete(&self, working_set: &mut WorkingSet<S>) {
         working_set.delete_value(self.prefix(), &SingletonKey);
     }
 


### PR DESCRIPTION
This PR changes the API of the modules system. Now `genesis, query & call` methods accept `&self` instead of `&mut self`  The methods modify `WorkingSet`, which is already `&mut`, so there is no need for the additional ` &mut`