### PR TITLE
Bank module implementation

### DIFF
--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -55,6 +55,12 @@ impl<'a> TryFrom<&'a [u8]> for Address {
     }
 }
 
+impl From<[u8; 32]> for Address {
+    fn from(addr: [u8; 32]) -> Self {
+        Self { addr }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum SigVerificationError {
     #[error("Bad signature")]
@@ -83,7 +89,7 @@ pub trait PublicKey {
 
 /// Spec contains types common for all modules.
 pub trait Spec {
-    type Address: AddressTrait + borsh::BorshDeserialize + borsh::BorshSerialize;
+    type Address: AddressTrait + borsh::BorshDeserialize + borsh::BorshSerialize + From<[u8; 32]>;
 
     type Storage: Storage + Clone;
 

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -1,12 +1,13 @@
-use anyhow::Result;
-use sov_modules_api::CallResponse;
+use anyhow::{bail, Result};
+use sov_modules_api::{CallResponse, Spec};
 use sov_state::WorkingSet;
 
-use crate::{Amount, Bank, Coins};
+use crate::{Amount, Bank, Coins, Token};
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub enum CallMessage<C: sov_modules_api::Context> {
     CreateToken {
+        salt: u64,
         token_name: String,
         initial_balance: Amount,
         minter_address: C::Address,
@@ -22,17 +23,53 @@ pub enum CallMessage<C: sov_modules_api::Context> {
     },
 }
 
+fn contract_address<C: sov_modules_api::Context>() -> C::Address {
+    todo!()
+}
+
+fn burn_address<C: sov_modules_api::Context>() -> C::Address {
+    todo!()
+}
+
+fn prefix() -> sov_modules_api::Prefix {
+    todo!()
+}
+
 impl<C: sov_modules_api::Context> Bank<C> {
     pub fn create_token(
         &self,
-        _token_name: String,
-        _initial_balance: Amount,
-        _minter_address: C::Address,
-        _context: &C,
-        _working_set: &mut WorkingSet<C::Storage>,
+        token_name: String,
+        initial_balance: Amount,
+        minter_address: C::Address,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        // This function will create a unique address for `token_name` and insert, the new `Token` to self.tokens
-        todo!()
+        //let sender_address = context.sender();
+        // salt
+        // hash(name)
+
+        let contract_address = contract_address::<C>();
+
+        match self.tokens.get(&contract_address, working_set) {
+            Some(_) => bail!("todo"),
+
+            None => {
+                let prefix = prefix();
+                let balances = sov_state::StateMap::new(prefix.into());
+                balances.set(&minter_address, initial_balance, working_set);
+
+                let token = Token::<C> {
+                    name: token_name,
+                    total_supply: initial_balance,
+                    burn_address: burn_address::<C>(),
+                    balances,
+                };
+
+                self.tokens.set(&contract_address, token, working_set);
+            }
+        };
+
+        Ok(CallResponse::default())
     }
 
     pub fn transfer(
@@ -43,8 +80,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let token_address = coins.token_address;
-
         let token = self.tokens.get_or_err(&token_address, working_set)?;
+
         token.transfer(context.sender(), &to, coins.amount, working_set)
     }
 

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -49,10 +49,10 @@ impl<C: sov_modules_api::Context> Bank<C> {
             Some(_) => bail!("Token address already exists"),
 
             None => {
-                let prefix = self.prefix(&token_address);
+                let token_prefix = self.prefix_from_address(&token_address);
 
                 // Create balances map and initialize minter balance.
-                let balances = sov_state::StateMap::new(prefix);
+                let balances = sov_state::StateMap::new(token_prefix);
                 balances.set(&minter_address, initial_balance, working_set);
 
                 let token = Token::<C> {
@@ -92,7 +92,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
-    fn prefix(&self, token_address: &C::Address) -> sov_state::Prefix {
+    fn prefix_from_address(&self, token_address: &C::Address) -> sov_state::Prefix {
         sov_state::Prefix::new(token_address.as_ref().to_vec())
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -24,7 +24,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
-    pub fn create_token(
+    pub(crate) fn create_token(
         &self,
         token_name: String,
         salt: u64,
@@ -33,7 +33,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let token_address = self.create_token_address(&token_name, context.sender(), salt);
+        let token_address = super::create_token_address::<C>(&token_name, context.sender(), salt);
 
         match self.tokens.get(&token_address, working_set) {
             Some(_) => bail!("todo"),
@@ -57,7 +57,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         Ok(CallResponse::default())
     }
 
-    pub fn transfer(
+    pub(crate) fn transfer(
         &self,
         to: C::Address,
         coins: Coins<C::Address>,
@@ -70,7 +70,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         token.transfer(context.sender(), &to, coins.amount, working_set)
     }
 
-    pub fn burn(
+    pub(crate) fn burn(
         &self,
         coins: Coins<C::Address>,
         context: &C,
@@ -93,22 +93,6 @@ impl<C: sov_modules_api::Context> Bank<C> {
 
         let hash = hasher.finalize();
         sov_state::Prefix::new(hash.to_vec())
-    }
-
-    fn create_token_address(
-        &self,
-        token_name: &str,
-        sender_address: &C::Address,
-        salt: u64,
-    ) -> C::Address {
-        let mut hasher = C::Hasher::new();
-        hasher.update(sender_address.as_ref());
-        hasher.update(token_name.as_bytes());
-        hasher.update(&salt.to_le_bytes());
-
-        let hash = hasher.finalize();
-        // TODO remove unwrap
-        C::Address::try_from(&hash).unwrap()
     }
 
     fn create_burn_address(&self, token_address: &C::Address) -> C::Address {

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -59,7 +59,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
                 let token = Token::<C> {
                     name: token_name,
                     total_supply: initial_balance,
-                    burn_address: super::create_burn_address::<C>(&token_address),
+                    special_address: super::create_special_address::<C>(&token_address),
                     balances,
                 };
 

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -1,7 +1,6 @@
 use crate::{Amount, Bank, Coins, Token};
 use anyhow::{bail, Result};
 use sov_modules_api::CallResponse;
-use sov_modules_api::Hasher;
 use sov_state::WorkingSet;
 
 /// This enumeration represents the available call messages for interacting with the bank module.
@@ -77,9 +76,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let token_address = coins.token_address;
-        let token = self.tokens.get_or_err(&token_address, working_set)?;
-
+        let token = self.tokens.get_or_err(&coins.token_address, working_set)?;
         token.transfer(context.sender(), &to, coins.amount, working_set)
     }
 
@@ -89,22 +86,13 @@ impl<C: sov_modules_api::Context> Bank<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let token_address = coins.token_address;
-        let token = self.tokens.get_or_err(&token_address, working_set)?;
-
+        let token = self.tokens.get_or_err(&coins.token_address, working_set)?;
         token.burn(context.sender(), coins.amount, working_set)
     }
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
     fn prefix(&self, token_address: &C::Address) -> sov_state::Prefix {
-        let mut hasher = C::Hasher::new();
-        hasher.update(self.address.as_ref());
-        hasher.update(token_address.as_ref());
-
-        //TODO address/token_address
-
-        let hash = hasher.finalize();
-        sov_state::Prefix::new(hash.to_vec())
+        sov_state::Prefix::new(token_address.as_ref().to_vec())
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -37,20 +37,26 @@ impl<C: sov_modules_api::Context> Bank<C> {
 
     pub fn transfer(
         &self,
-        _to: C::Address,
-        _coins: Coins<C::Address>,
-        _context: &C,
-        _working_set: &mut WorkingSet<C::Storage>,
+        to: C::Address,
+        coins: Coins<C::Address>,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        todo!()
+        let token_address = coins.token_address;
+
+        let token = self.tokens.get_or_err(&token_address, working_set)?;
+        token.transfer(context.sender(), &to, coins.amount, working_set)
     }
 
     pub fn burn(
         &self,
-        _coins: Coins<C::Address>,
-        _context: &C,
-        _working_set: &mut WorkingSet<C::Storage>,
+        coins: Coins<C::Address>,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        todo!()
+        let token_address = coins.token_address;
+        let token = self.tokens.get_or_err(&token_address, working_set)?;
+
+        token.burn(context.sender(), coins.amount, working_set)
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -4,21 +4,32 @@ use sov_modules_api::CallResponse;
 use sov_modules_api::Hasher;
 use sov_state::WorkingSet;
 
+/// This enumeration represents the available call messages for interacting with the bank module.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub enum CallMessage<C: sov_modules_api::Context> {
+    /// Creates a new token with the specified name and initial balance.
     CreateToken {
+        /// salt: a random value use to create a unique token address.
         salt: u64,
+        /// token_name: the name of the new token
         token_name: String,
+        /// initial_balance: the initial balance of the new token
         initial_balance: Amount,
+        /// minter_address: the address of the account that minted new tokens.
         minter_address: C::Address,
     },
 
+    /// Transfers a specified amount of tokens to the specified address.
     Transfer {
+        /// to: the address to which the tokens will be transferred.
         to: C::Address,
+        /// coins: the amount of tokens to transfer.
         coins: Coins<C::Address>,
     },
 
+    /// Burns a specified amount of tokens.
     Burn {
+        /// coins: the amount of tokens to burn.
         coins: Coins<C::Address>,
     },
 }

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -12,7 +12,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         salt: u64,
         /// token_name: the name of the new token.
         token_name: String,
-        /// initial_balance: the initial balance of the new token
+        /// initial_balance: the initial balance of the new token.
         initial_balance: Amount,
         /// minter_address: the address of the account that minted new tokens.
         minter_address: C::Address,
@@ -58,7 +58,6 @@ impl<C: sov_modules_api::Context> Bank<C> {
                 let token = Token::<C> {
                     name: token_name,
                     total_supply: initial_balance,
-                    special_address: super::create_special_address::<C>(&token_address),
                     balances,
                 };
 
@@ -87,7 +86,12 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        token.burn(context.sender(), coins.amount, working_set)
+        token.burn(
+            context.sender(),
+            &coins.token_address,
+            coins.amount,
+            working_set,
+        )
     }
 }
 

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -8,27 +8,27 @@ use sov_state::WorkingSet;
 pub enum CallMessage<C: sov_modules_api::Context> {
     /// Creates a new token with the specified name and initial balance.
     CreateToken {
-        /// salt: a random value use to create a unique token address.
+        /// Random value use to create a unique token address.
         salt: u64,
-        /// token_name: the name of the new token.
+        /// The name of the new token.
         token_name: String,
-        /// initial_balance: the initial balance of the new token.
+        /// The initial balance of the new token.
         initial_balance: Amount,
-        /// minter_address: the address of the account that minted new tokens.
+        /// The address of the account that minted new tokens.
         minter_address: C::Address,
     },
 
     /// Transfers a specified amount of tokens to the specified address.
     Transfer {
-        /// to: the address to which the tokens will be transferred.
+        /// The address to which the tokens will be transferred.
         to: C::Address,
-        /// coins: the amount of tokens to transfer.
+        /// The amount of tokens to transfer.
         coins: Coins<C::Address>,
     },
 
     /// Burns a specified amount of tokens.
     Burn {
-        /// coins: the amount of tokens to burn.
+        /// The amount of tokens to burn.
         coins: Coins<C::Address>,
     },
 }
@@ -45,25 +45,23 @@ impl<C: sov_modules_api::Context> Bank<C> {
     ) -> Result<CallResponse> {
         let token_address = super::create_token_address::<C>(&token_name, context.sender(), salt);
 
-        match self.tokens.get(&token_address, working_set) {
-            Some(_) => bail!("Token address already exists"),
+        if self.tokens.get(&token_address, working_set).is_some() {
+            bail!("Token address already exists");
+        }
 
-            None => {
-                let token_prefix = self.prefix_from_address(&token_address);
+        let token_prefix = self.prefix_from_address(&token_address);
 
-                // Create balances map and initialize minter balance.
-                let balances = sov_state::StateMap::new(token_prefix);
-                balances.set(&minter_address, initial_balance, working_set);
+        // Create balances map and initialize minter balance.
+        let balances = sov_state::StateMap::new(token_prefix);
+        balances.set(&minter_address, initial_balance, working_set);
 
-                let token = Token::<C> {
-                    name: token_name,
-                    total_supply: initial_balance,
-                    balances,
-                };
-
-                self.tokens.set(&token_address, token, working_set);
-            }
+        let token = Token::<C> {
+            name: token_name,
+            total_supply: initial_balance,
+            balances,
         };
+
+        self.tokens.set(&token_address, token, working_set);
 
         Ok(CallResponse::default())
     }

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -1,5 +1,6 @@
 use sov_modules_api::Hasher;
 
+/// Derives token address from `token_name`, `sender` and `salt`.
 pub fn create_token_address<C: sov_modules_api::Context>(
     token_name: &str,
     sender_address: &C::Address,
@@ -9,6 +10,17 @@ pub fn create_token_address<C: sov_modules_api::Context>(
     hasher.update(sender_address.as_ref());
     hasher.update(token_name.as_bytes());
     hasher.update(&salt.to_le_bytes());
+
+    let hash = hasher.finalize();
+    // TODO remove unwrap
+    C::Address::try_from(&hash).unwrap()
+}
+
+/// Derives burn address for a given token.
+pub fn create_burn_address<C: sov_modules_api::Context>(token_address: &C::Address) -> C::Address {
+    let mut hasher = C::Hasher::new();
+    hasher.update(token_address.as_ref());
+    hasher.update(&[0; 32]);
 
     let hash = hasher.finalize();
     // TODO remove unwrap

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -1,0 +1,16 @@
+use sov_modules_api::Hasher;
+
+pub fn create_token_address<C: sov_modules_api::Context>(
+    token_name: &str,
+    sender_address: &C::Address,
+    salt: u64,
+) -> C::Address {
+    let mut hasher = C::Hasher::new();
+    hasher.update(sender_address.as_ref());
+    hasher.update(token_name.as_bytes());
+    hasher.update(&salt.to_le_bytes());
+
+    let hash = hasher.finalize();
+    // TODO remove unwrap
+    C::Address::try_from(&hash).unwrap()
+}

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -1,8 +1,5 @@
 use sov_modules_api::Hasher;
 
-// Const used for creating `special_address`
-const SPECIAL: [u8; 32] = [0; 32];
-
 /// Derives token address from `token_name`, `sender` and `salt`.
 pub fn create_token_address<C: sov_modules_api::Context>(
     token_name: &str,
@@ -13,18 +10,6 @@ pub fn create_token_address<C: sov_modules_api::Context>(
     hasher.update(sender_address.as_ref());
     hasher.update(token_name.as_bytes());
     hasher.update(&salt.to_le_bytes());
-
-    let hash = hasher.finalize();
-    C::Address::from(hash)
-}
-
-/// Derives `special address` for a given token.
-pub fn create_special_address<C: sov_modules_api::Context>(
-    token_address: &C::Address,
-) -> C::Address {
-    let mut hasher = C::Hasher::new();
-    hasher.update(token_address.as_ref());
-    hasher.update(&SPECIAL);
 
     let hash = hasher.finalize();
     C::Address::from(hash)

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -15,7 +15,6 @@ pub fn create_token_address<C: sov_modules_api::Context>(
     hasher.update(&salt.to_le_bytes());
 
     let hash = hasher.finalize();
-
     C::Address::from(hash)
 }
 

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -15,8 +15,8 @@ pub fn create_token_address<C: sov_modules_api::Context>(
     hasher.update(&salt.to_le_bytes());
 
     let hash = hasher.finalize();
-    // TODO remove unwrap
-    C::Address::try_from(&hash).unwrap()
+
+    C::Address::from(hash)
 }
 
 /// Derives `special address` for a given token.
@@ -28,6 +28,5 @@ pub fn create_special_address<C: sov_modules_api::Context>(
     hasher.update(&SPECIAL);
 
     let hash = hasher.finalize();
-    // TODO remove unwrap
-    C::Address::try_from(&hash).unwrap()
+    C::Address::from(hash)
 }

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -1,5 +1,8 @@
 use sov_modules_api::Hasher;
 
+// Const used for creating `special_address`
+const SPECIAL: [u8; 32] = [0; 32];
+
 /// Derives token address from `token_name`, `sender` and `salt`.
 pub fn create_token_address<C: sov_modules_api::Context>(
     token_name: &str,
@@ -16,11 +19,13 @@ pub fn create_token_address<C: sov_modules_api::Context>(
     C::Address::try_from(&hash).unwrap()
 }
 
-/// Derives burn address for a given token.
-pub fn create_burn_address<C: sov_modules_api::Context>(token_address: &C::Address) -> C::Address {
+/// Derives `special address` for a given token.
+pub fn create_special_address<C: sov_modules_api::Context>(
+    token_address: &C::Address,
+) -> C::Address {
     let mut hasher = C::Hasher::new();
     hasher.update(token_address.as_ref());
-    hasher.update(&[0; 32]);
+    hasher.update(&SPECIAL);
 
     let hash = hasher.finalize();
     // TODO remove unwrap

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -14,7 +14,10 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
-///
+/// The Bank module manages user balances. It provides functionality for:
+/// - Token creation.
+/// - Token transfers.
+/// - Token burn.
 #[derive(ModuleInfo)]
 pub struct Bank<C: sov_modules_api::Context> {
     /// The address of the bank module.

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -6,7 +6,7 @@ mod query;
 mod tests;
 mod token;
 
-pub use create_token::create_token_address;
+pub use create_token::{create_burn_address, create_token_address};
 use token::Token;
 pub use token::{Amount, Coins};
 

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -1,8 +1,11 @@
 mod call;
 mod genesis;
 mod query;
+#[cfg(test)]
+mod tests;
 mod token;
 use sov_modules_api::Error;
+use sov_modules_api::Hasher;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 pub use token::{Amount, Coins, Token};
@@ -29,19 +32,70 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
 
     fn call(
         &self,
-        _msg: Self::CallMessage,
-        _context: &Self::Context,
-        _working_set: &mut WorkingSet<C::Storage>,
+        msg: Self::CallMessage,
+        context: &Self::Context,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse, Error> {
-        todo!()
+        match msg {
+            call::CallMessage::CreateToken {
+                salt,
+                token_name,
+                initial_balance,
+                minter_address,
+            } => Ok(self.create_token(
+                token_name,
+                salt,
+                initial_balance,
+                minter_address,
+                context,
+                working_set,
+            )?),
+            call::CallMessage::Transfer { to, coins } => {
+                Ok(self.transfer(to, coins, context, working_set)?)
+            }
+            call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
+        }
     }
 
     #[cfg(feature = "native")]
     fn query(
         &self,
-        _msg: Self::QueryMessage,
-        _working_set: &mut WorkingSet<C::Storage>,
+        msg: Self::QueryMessage,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> sov_modules_api::QueryResponse {
-        todo!()
+        match msg {
+            query::QueryMessage::GetBalance {
+                user_address,
+                token_address,
+            } => {
+                let response =
+                    serde_json::to_vec(&self.balance_of(user_address, token_address, working_set))
+                        .unwrap();
+
+                sov_modules_api::QueryResponse { response }
+            }
+
+            query::QueryMessage::GetTotalSupply { token_address } => {
+                let response =
+                    serde_json::to_vec(&self.supply_of(token_address, working_set)).unwrap();
+
+                sov_modules_api::QueryResponse { response }
+            }
+        }
     }
+}
+
+fn create_token_address<C: sov_modules_api::Context>(
+    token_name: &str,
+    sender_address: &C::Address,
+    salt: u64,
+) -> C::Address {
+    let mut hasher = C::Hasher::new();
+    hasher.update(sender_address.as_ref());
+    hasher.update(token_name.as_bytes());
+    hasher.update(&salt.to_le_bytes());
+
+    let hash = hasher.finalize();
+    // TODO remove unwrap
+    C::Address::try_from(&hash).unwrap()
 }

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -1,14 +1,17 @@
 mod call;
+mod create_token;
 mod genesis;
 mod query;
 #[cfg(test)]
 mod tests;
 mod token;
+
+pub use create_token::create_token_address;
+pub use token::{Amount, Coins, Token};
+
 use sov_modules_api::Error;
-use sov_modules_api::Hasher;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
-pub use token::{Amount, Coins, Token};
 
 #[derive(ModuleInfo)]
 pub struct Bank<C: sov_modules_api::Context> {
@@ -83,19 +86,4 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             }
         }
     }
-}
-
-fn create_token_address<C: sov_modules_api::Context>(
-    token_name: &str,
-    sender_address: &C::Address,
-    salt: u64,
-) -> C::Address {
-    let mut hasher = C::Hasher::new();
-    hasher.update(sender_address.as_ref());
-    hasher.update(token_name.as_bytes());
-    hasher.update(&salt.to_le_bytes());
-
-    let hash = hasher.finalize();
-    // TODO remove unwrap
-    C::Address::try_from(&hash).unwrap()
 }

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -13,9 +13,6 @@ pub struct Bank<C: sov_modules_api::Context> {
     pub address: C::Address,
 
     #[state]
-    pub names: sov_state::StateMap<String, C::Address>,
-
-    #[state]
     pub tokens: sov_state::StateMap<C::Address, Token<C>>,
 }
 

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -7,19 +7,23 @@ mod tests;
 mod token;
 
 pub use create_token::create_token_address;
-pub use token::{Amount, Coins, Token};
+use token::Token;
+pub use token::{Amount, Coins};
 
 use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
+///
 #[derive(ModuleInfo)]
 pub struct Bank<C: sov_modules_api::Context> {
+    /// The address of the bank module.
     #[address]
-    pub address: C::Address,
+    pub(crate) address: C::Address,
 
+    /// A mapping of addresses to tokens in the bank.
     #[state]
-    pub tokens: sov_state::StateMap<C::Address, Token<C>>,
+    pub(crate) tokens: sov_state::StateMap<C::Address, Token<C>>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
@@ -53,9 +57,11 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
                 context,
                 working_set,
             )?),
+
             call::CallMessage::Transfer { to, coins } => {
                 Ok(self.transfer(to, coins, context, working_set)?)
             }
+
             call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
         }
     }

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -6,7 +6,7 @@ mod query;
 mod tests;
 mod token;
 
-pub use create_token::{create_special_address, create_token_address};
+pub use create_token::create_token_address;
 use token::Token;
 pub use token::{Amount, Coins};
 

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -6,7 +6,7 @@ mod query;
 mod tests;
 mod token;
 
-pub use create_token::{create_burn_address, create_token_address};
+pub use create_token::{create_special_address, create_token_address};
 use token::Token;
 pub use token::{Amount, Coins};
 

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -1,24 +1,11 @@
 mod call;
 mod genesis;
 mod query;
+mod token;
 use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
-
-type Amount = u64;
-
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
-pub struct Coins<Address: sov_modules_api::AddressTrait> {
-    amount: Amount,
-    token_address: Address,
-}
-
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
-pub struct Token<Address: sov_modules_api::AddressTrait> {
-    name: String,
-    total_supply: u64,
-    balances: sov_state::StateMap<Address, Amount>,
-}
+pub use token::{Amount, Coins, Token};
 
 #[derive(ModuleInfo)]
 pub struct Bank<C: sov_modules_api::Context> {
@@ -29,7 +16,7 @@ pub struct Bank<C: sov_modules_api::Context> {
     pub names: sov_state::StateMap<String, C::Address>,
 
     #[state]
-    pub tokens: sov_state::StateMap<C::Address, Token<C::Address>>,
+    pub tokens: sov_state::StateMap<C::Address, Token<C>>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {

--- a/sov-modules/sov-modules-impl/bank/src/query.rs
+++ b/sov-modules/sov-modules-impl/bank/src/query.rs
@@ -16,30 +16,39 @@ pub enum QueryMessage<C: sov_modules_api::Context> {
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub struct BalanceResponse {
-    amount: Amount,
+    amount: Option<Amount>,
 }
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub struct TotalSupplyResponse {
-    amount: Amount,
+    amount: Option<Amount>,
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
     pub fn balance_of(
         &self,
-        _user_address: C::Address,
-        _token_address: C::Address,
-        _working_set: &mut WorkingSet<C::Storage>,
+        user_address: C::Address,
+        token_address: C::Address,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> BalanceResponse {
-        todo!()
+        BalanceResponse {
+            amount: self
+                .tokens
+                .get(&token_address, working_set)
+                .and_then(|token| token.balances.get(&user_address, working_set)),
+        }
     }
 
     pub fn supply_of(
         &self,
-        _user_address: C::Address,
-        _token_address: C::Address,
-        _working_set: &mut WorkingSet<C::Storage>,
+        token_address: C::Address,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> TotalSupplyResponse {
-        todo!()
+        TotalSupplyResponse {
+            amount: self
+                .tokens
+                .get(&token_address, working_set)
+                .map(|token| token.total_supply),
+        }
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/query.rs
+++ b/sov-modules/sov-modules-impl/bank/src/query.rs
@@ -14,18 +14,18 @@ pub enum QueryMessage<C: sov_modules_api::Context> {
     },
 }
 
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
 pub struct BalanceResponse {
     amount: Option<Amount>,
 }
 
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
 pub struct TotalSupplyResponse {
     amount: Option<Amount>,
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
-    pub fn balance_of(
+    pub(crate) fn balance_of(
         &self,
         user_address: C::Address,
         token_address: C::Address,
@@ -39,7 +39,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         }
     }
 
-    pub fn supply_of(
+    pub(crate) fn supply_of(
         &self,
         token_address: C::Address,
         working_set: &mut WorkingSet<C::Storage>,

--- a/sov-modules/sov-modules-impl/bank/src/query.rs
+++ b/sov-modules/sov-modules-impl/bank/src/query.rs
@@ -16,12 +16,12 @@ pub enum QueryMessage<C: sov_modules_api::Context> {
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
 pub struct BalanceResponse {
-    amount: Option<Amount>,
+    pub amount: Option<Amount>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
 pub struct TotalSupplyResponse {
-    amount: Option<Amount>,
+    pub amount: Option<Amount>,
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {

--- a/sov-modules/sov-modules-impl/bank/src/query.rs
+++ b/sov-modules/sov-modules-impl/bank/src/query.rs
@@ -1,17 +1,16 @@
+use crate::{Amount, Bank};
 use sov_state::WorkingSet;
 
-use crate::{Amount, Bank};
-
+/// This enumeration represents the available query messages for querying the bank module.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub enum QueryMessage<C: sov_modules_api::Context> {
+    /// Gets the balance of a specified token for a specified user.
     GetBalance {
         user_address: C::Address,
         token_address: C::Address,
     },
-
-    GetTotalSupply {
-        token_address: C::Address,
-    },
+    /// Gets the total supply of a specified token.
+    GetTotalSupply { token_address: C::Address },
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -42,6 +42,7 @@ impl TestBank {
                 token_address: self.token_address.clone(),
             },
         };
+
         self.bank
             .call(transfer, &self.minter_context, &mut self.working_set)
             .unwrap();
@@ -54,6 +55,7 @@ impl TestBank {
                 token_address: self.token_address.clone(),
             },
         };
+
         self.bank
             .call(burn, context, &mut self.working_set)
             .unwrap();
@@ -66,7 +68,6 @@ impl TestBank {
         };
 
         let resp = self.bank.query(query, &mut self.working_set);
-
         serde_json::from_slice(&resp.response).unwrap()
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -17,13 +17,14 @@ struct TestBank {
     minter_address: <C as Spec>::Address,
     minter_context: C,
     token_address: <C as Spec>::Address,
+    salt: u64,
     working_set: WorkingSet<<C as Spec>::Storage>,
 }
 
 impl TestBank {
     fn create_token(&mut self, initial_balance: u64, sender_context: &C) {
         let create_token = call::CallMessage::CreateToken::<C> {
-            salt: 0,
+            salt: self.salt,
             token_name: "Token1".to_owned(),
             initial_balance,
             minter_address: self.minter_address.clone(),
@@ -94,6 +95,7 @@ fn create_test_bank() -> (TestBank, C) {
             minter_address,
             minter_context,
             token_address,
+            salt,
             working_set,
         },
         sender_context,

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -1,8 +1,9 @@
 use crate::{
     call,
     query::{self, QueryMessage},
-    Bank,
+    Bank, Coins,
 };
+
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey},
     Context, Module, ModuleInfo, PublicKey, Spec,
@@ -11,39 +12,127 @@ use sov_state::{ProverStorage, WorkingSet};
 
 type C = MockContext;
 
-#[test]
-fn test_create_token() {
-    let working_set = &mut WorkingSet::new(ProverStorage::temporary());
-    let bank = &mut Bank::<C>::new();
+struct TestBank {
+    bank: Bank<C>,
+    minter_address: <C as Spec>::Address,
+    minter_context: C,
+    token_address: <C as Spec>::Address,
+    working_set: WorkingSet<<C as Spec>::Storage>,
+}
 
-    let sender = MockPublicKey::try_from("pub_key").unwrap();
+impl TestBank {
+    fn create_token(&mut self, initial_balance: u64, sender_context: &C) {
+        let create_token = call::CallMessage::CreateToken::<C> {
+            salt: 0,
+            token_name: "Token1".to_owned(),
+            initial_balance,
+            minter_address: self.minter_address.clone(),
+        };
+
+        self.bank
+            .call(create_token, sender_context, &mut self.working_set)
+            .unwrap();
+    }
+
+    fn transfer(&mut self, amount: u64, receiver_address: <C as Spec>::Address) {
+        let transfer = call::CallMessage::Transfer {
+            to: receiver_address,
+            coins: Coins {
+                amount,
+                token_address: self.token_address.clone(),
+            },
+        };
+        self.bank
+            .call(transfer, &self.minter_context, &mut self.working_set)
+            .unwrap();
+    }
+
+    fn burn(&mut self, amount: u64, context: &C) {
+        let burn = call::CallMessage::Burn {
+            coins: Coins {
+                amount,
+                token_address: self.token_address.clone(),
+            },
+        };
+        self.bank
+            .call(burn, context, &mut self.working_set)
+            .unwrap();
+    }
+
+    fn query_balance(&mut self, user_address: <C as Spec>::Address) -> query::BalanceResponse {
+        let query = QueryMessage::GetBalance {
+            user_address,
+            token_address: self.token_address.clone(),
+        };
+
+        let resp = self.bank.query(query, &mut self.working_set);
+
+        serde_json::from_slice(&resp.response).unwrap()
+    }
+}
+
+fn create_test_bank() -> (TestBank, C) {
+    let bank = Bank::<C>::new();
+    let working_set = WorkingSet::new(ProverStorage::temporary());
+
+    let sender = <C as Spec>::PublicKey::try_from("pub_key_sender").unwrap();
     let sender_address = sender.to_address::<<C as Spec>::Address>();
     let sender_context = C::new(sender_address.clone());
-    let minter_address = <C as Spec>::Address::try_from([0; 32].as_ref()).unwrap();
+
+    let minter = <C as Spec>::PublicKey::try_from("minter_sender").unwrap();
+    let minter_address = minter.to_address::<<C as Spec>::Address>();
+    let minter_context = C::new(minter_address.clone());
 
     let salt = 0;
     let token_name = "Token1".to_owned();
 
     let token_address = super::create_token_address::<C>(&token_name, &sender_address, salt);
+    (
+        TestBank {
+            bank,
+            minter_address,
+            minter_context,
+            token_address,
+            working_set,
+        },
+        sender_context,
+    )
+}
 
-    let create_token = call::CallMessage::CreateToken::<C> {
-        salt: 0,
-        token_name: "Token1".to_owned(),
-        initial_balance: 100,
-        minter_address: minter_address.clone(),
-    };
+#[test]
+fn test_bank() {
+    let initial_balance = 100;
+    let (mut test_bank, sender_context) = create_test_bank();
 
-    bank.call(create_token, &sender_context, working_set)
-        .unwrap();
+    // Create token
+    {
+        test_bank.create_token(initial_balance, &sender_context);
+        let query_response = test_bank.query_balance(test_bank.minter_address.clone());
+        assert_eq!(query_response.amount, Some(initial_balance));
+    }
 
-    let query = QueryMessage::GetBalance {
-        user_address: minter_address,
-        token_address,
-    };
+    let amount = 22;
+    let receiver = MockPublicKey::try_from("pub_key_receiver").unwrap();
+    let receiver_address = receiver.to_address::<<C as Spec>::Address>();
+    let receiver_context = C::new(receiver_address.clone());
 
-    let resp = bank.query(query, working_set);
+    // Transfer coins
+    {
+        test_bank.transfer(amount, receiver_address.clone());
 
-    let query_response: query::BalanceResponse = serde_json::from_slice(&resp.response).unwrap();
+        let query_response = test_bank.query_balance(test_bank.minter_address.clone());
+        assert_eq!(query_response.amount, Some(initial_balance - amount));
+    }
 
-    println!("RSP {:?}", query_response)
+    // Burn coins
+    {
+        let query_response = test_bank.query_balance(receiver_address.clone());
+        assert_eq!(query_response.amount, Some(amount));
+
+        let burn_amount = 22;
+        test_bank.burn(burn_amount, &receiver_context);
+
+        let query_response = test_bank.query_balance(receiver_address);
+        assert_eq!(query_response.amount, Some(amount - burn_amount));
+    }
 }

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -1,0 +1,49 @@
+use crate::{
+    call,
+    query::{self, QueryMessage},
+    Bank,
+};
+use sov_modules_api::{
+    mocks::{MockContext, MockPublicKey},
+    Context, Module, ModuleInfo, PublicKey, Spec,
+};
+use sov_state::{ProverStorage, WorkingSet};
+
+type C = MockContext;
+
+#[test]
+fn test_create_token() {
+    let working_set = &mut WorkingSet::new(ProverStorage::temporary());
+    let bank = &mut Bank::<C>::new();
+
+    let sender = MockPublicKey::try_from("pub_key").unwrap();
+    let sender_address = sender.to_address::<<C as Spec>::Address>();
+    let sender_context = C::new(sender_address.clone());
+    let minter_address = <C as Spec>::Address::try_from([0; 32].as_ref()).unwrap();
+
+    let salt = 0;
+    let token_name = "Token1".to_owned();
+
+    let token_address = super::create_token_address::<C>(&token_name, &sender_address, salt);
+
+    let create_token = call::CallMessage::CreateToken::<C> {
+        salt: 0,
+        token_name: "Token1".to_owned(),
+        initial_balance: 100,
+        minter_address: minter_address.clone(),
+    };
+
+    bank.call(create_token, &sender_context, working_set)
+        .unwrap();
+
+    let query = QueryMessage::GetBalance {
+        user_address: minter_address,
+        token_address,
+    };
+
+    let resp = bank.query(query, working_set);
+
+    let query_response: query::BalanceResponse = serde_json::from_slice(&resp.response).unwrap();
+
+    println!("RSP {:?}", query_response)
+}

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -13,9 +13,13 @@ pub struct Coins<Address: sov_modules_api::AddressTrait> {
 /// This struct represents a token in the bank module.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub(crate) struct Token<C: sov_modules_api::Context> {
+    /// Name of the token.
     pub(crate) name: String,
+    /// Total supply of the coins.
     pub(crate) total_supply: u64,
-    pub(crate) burn_address: C::Address,
+    /// The special address can be used as burn address or to store temporarily locked coins.
+    pub(crate) special_address: C::Address,
+    /// Mapping from user address to user balance.
     pub(crate) balances: sov_state::StateMap<C::Address, Amount>,
 }
 
@@ -31,7 +35,7 @@ impl<C: sov_modules_api::Context> Token<C> {
 
         let from_balance = match from_balance.checked_sub(amount) {
             Some(from_balance) => from_balance,
-            // TODO: Add from address to the message (we need pretty print for Address)
+            // TODO: Add `from` address to the message (we need pretty print for Address first)
             None => bail!("Insufficient funds"),
         };
 
@@ -50,6 +54,6 @@ impl<C: sov_modules_api::Context> Token<C> {
         amount: Amount,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        self.transfer(from, &self.burn_address, amount, working_set)
+        self.transfer(from, &self.special_address, amount, working_set)
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -17,7 +17,6 @@ pub(crate) struct Token<C: sov_modules_api::Context> {
     pub(crate) name: String,
     /// Total supply of the coins.
     pub(crate) total_supply: u64,
-
     /// Mapping from user address to user balance.
     pub(crate) balances: sov_state::StateMap<C::Address, Amount>,
 }

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -1,0 +1,52 @@
+use anyhow::{bail, Result};
+use sov_modules_api::CallResponse;
+use sov_state::WorkingSet;
+
+pub type Amount = u64;
+
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
+pub struct Coins<Address: sov_modules_api::AddressTrait> {
+    pub(crate) amount: Amount,
+    pub(crate) token_address: Address,
+}
+
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
+pub struct Token<C: sov_modules_api::Context> {
+    name: String,
+    total_supply: u64,
+    burn_address: C::Address,
+    balances: sov_state::StateMap<C::Address, Amount>,
+}
+
+impl<C: sov_modules_api::Context> Token<C> {
+    pub fn transfer(
+        &self,
+        from: &C::Address,
+        to: &C::Address,
+        amount: Amount,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse> {
+        let from_balance = self.balances.get_or_err(from, working_set)?;
+
+        let from_balance = match from_balance.checked_sub(amount) {
+            Some(from_balance) => from_balance,
+            None => bail!("todo"),
+        };
+
+        let to_balance = self.balances.get(to, working_set).unwrap_or_default() + amount;
+
+        self.balances.set(from, from_balance, working_set);
+        self.balances.set(to, to_balance, working_set);
+
+        Ok(CallResponse::default())
+    }
+
+    pub fn burn(
+        &self,
+        from: &C::Address,
+        amount: Amount,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse> {
+        self.transfer(from, &self.burn_address, amount, working_set)
+    }
+}

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -17,8 +17,7 @@ pub(crate) struct Token<C: sov_modules_api::Context> {
     pub(crate) name: String,
     /// Total supply of the coins.
     pub(crate) total_supply: u64,
-    /// The special address can be used as burn address or to store temporarily locked coins.
-    pub(crate) special_address: C::Address,
+
     /// Mapping from user address to user balance.
     pub(crate) balances: sov_state::StateMap<C::Address, Amount>,
 }
@@ -51,9 +50,10 @@ impl<C: sov_modules_api::Context> Token<C> {
     pub(crate) fn burn(
         &self,
         from: &C::Address,
+        burn: &C::Address,
         amount: Amount,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        self.transfer(from, &self.special_address, amount, working_set)
+        self.transfer(from, burn, amount, working_set)
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -12,10 +12,10 @@ pub struct Coins<Address: sov_modules_api::AddressTrait> {
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub struct Token<C: sov_modules_api::Context> {
-    name: String,
-    total_supply: u64,
-    burn_address: C::Address,
-    balances: sov_state::StateMap<C::Address, Amount>,
+    pub(crate) name: String,
+    pub(crate) total_supply: u64,
+    pub(crate) burn_address: C::Address,
+    pub(crate) balances: sov_state::StateMap<C::Address, Amount>,
 }
 
 impl<C: sov_modules_api::Context> Token<C> {

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -6,12 +6,13 @@ pub type Amount = u64;
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub struct Coins<Address: sov_modules_api::AddressTrait> {
-    pub(crate) amount: Amount,
-    pub(crate) token_address: Address,
+    pub amount: Amount,
+    pub token_address: Address,
 }
 
+/// This struct represents a token in the bank module.
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
-pub struct Token<C: sov_modules_api::Context> {
+pub(crate) struct Token<C: sov_modules_api::Context> {
     pub(crate) name: String,
     pub(crate) total_supply: u64,
     pub(crate) burn_address: C::Address,
@@ -19,7 +20,7 @@ pub struct Token<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> Token<C> {
-    pub fn transfer(
+    pub(crate) fn transfer(
         &self,
         from: &C::Address,
         to: &C::Address,
@@ -41,7 +42,7 @@ impl<C: sov_modules_api::Context> Token<C> {
         Ok(CallResponse::default())
     }
 
-    pub fn burn(
+    pub(crate) fn burn(
         &self,
         from: &C::Address,
         amount: Amount,

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -31,9 +31,11 @@ impl<C: sov_modules_api::Context> Token<C> {
 
         let from_balance = match from_balance.checked_sub(amount) {
             Some(from_balance) => from_balance,
-            None => bail!("todo"),
+            // TODO: Add from address to the message (we need pretty print for Address)
+            None => bail!("Insufficient funds"),
         };
 
+        // We can't overflow here because the sum must be smaller than `total_supply` which is u64.
         let to_balance = self.balances.get(to, working_set).unwrap_or_default() + amount;
 
         self.balances.set(from, from_balance, working_set);

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -37,7 +37,7 @@ impl<C: sov_modules_api::Context> Token<C> {
             None => bail!("Insufficient funds"),
         };
 
-        // We can't overflow here because the sum must be smaller than `total_supply` which is u64.
+        // We can't overflow here because the sum must be smaller or eq to `total_supply` which is u64.
         let to_balance = self.balances.get(to, working_set).unwrap_or_default() + amount;
 
         self.balances.set(from, from_balance, working_set);


### PR DESCRIPTION
This PR introduces the following changes:
1. Implements `Bank` module functionality
2. Adds `From<[u8;32]>` implementation for `Address` (Our hash is always 32 bytes, and it makes sense to be able to derive an Address from hash)

Issue for better test coverage: https://github.com/Sovereign-Labs/sovereign/issues/163