### PR TITLE
Add tests for genesis initialisation in `Bank` & `Account`

### DIFF
--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -27,7 +27,7 @@ fn create_new_demo(path: impl AsRef<Path>) -> DemoApp {
     let storage = ProverStorage::with_path(path).unwrap();
     let tx_hooks = DemoAppTxHooks::new();
     let tx_verifier = DemoAppTxVerifier::new();
-    let genesis_config = GenesisConfig::new((), (), ());
+    let genesis_config = GenesisConfig::new((), (), accounts::AccountConfig { pub_keys: vec![] });
     AppTemplate::new(storage, runtime, tx_verifier, tx_hooks, genesis_config)
 }
 

--- a/sov-modules/sov-modules-impl/accounts/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/genesis.rs
@@ -1,10 +1,54 @@
-use crate::Accounts;
-use anyhow::Result;
+use crate::{Account, Accounts};
+use anyhow::{bail, Result};
+use sov_modules_api::PublicKey;
 use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> Accounts<C> {
-    pub(crate) fn init_module(&self, _working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
-        // TODO read initial accounts from "Config"
+    pub(crate) fn init_module(
+        &self,
+        config: &<Self as sov_modules_api::Module>::Config,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<()> {
+        for pub_key in config.pub_keys.iter() {
+            if self.accounts.get(pub_key, working_set).is_some() {
+                bail!("Account already exists")
+            }
+
+            self.create_default_account(pub_key.clone(), working_set)?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn create_default_account(
+        &self,
+        pub_key: C::PublicKey,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<Account<C>> {
+        let default_address = pub_key.to_address();
+        self.exit_if_address_exists(&default_address, working_set)?;
+
+        let new_account = Account {
+            addr: default_address.clone(),
+            nonce: 0,
+        };
+
+        self.accounts
+            .set(&pub_key, new_account.clone(), working_set);
+
+        self.public_keys.set(&default_address, pub_key, working_set);
+        Ok(new_account)
+    }
+
+    fn exit_if_address_exists(
+        &self,
+        address: &C::Address,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            self.public_keys.get(address, working_set).is_none(),
+            "Address already exists"
+        );
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -11,6 +11,10 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
+pub struct AccountConfig<C: sov_modules_api::Context> {
+    pub pub_keys: Vec<C::PublicKey>,
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq, Copy, Clone)]
 pub struct Account<C: sov_modules_api::Context> {
     pub addr: C::Address,
@@ -32,7 +36,7 @@ pub struct Accounts<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
     type Context = C;
 
-    type Config = ();
+    type Config = AccountConfig<C>;
 
     type CallMessage = call::CallMessage<C>;
 
@@ -40,10 +44,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Accounts<C> {
 
     fn genesis(
         &self,
-        _config: &Self::Config,
+        config: &Self::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(), Error> {
-        Ok(self.init_module(working_set)?)
+        Ok(self.init_module(config, working_set)?)
     }
 
     fn call(

--- a/sov-modules/sov-modules-impl/accounts/src/lib.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/lib.rs
@@ -11,6 +11,7 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
+/// Initial configuration for Accounts module.
 pub struct AccountConfig<C: sov_modules_api::Context> {
     pub pub_keys: Vec<C::PublicKey>,
 }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     call, hooks,
     query::{self, QueryMessage},
-    Accounts,
+    AccountConfig, Accounts,
 };
 use sov_modules_api::{
     mocks::{MockContext, MockPublicKey},
@@ -12,10 +12,45 @@ use sov_state::{ProverStorage, WorkingSet};
 type C = MockContext;
 
 #[test]
+fn test_config_account() {
+    let init_pub_key = MockPublicKey::try_from("init_pub_key").unwrap();
+    let init_pub_key_addr = init_pub_key.to_address::<<C as Spec>::Address>();
+
+    let account_config = AccountConfig::<C> {
+        pub_keys: vec![init_pub_key.clone()],
+    };
+
+    let accounts = &mut Accounts::<C>::new();
+    let native_working_set = &mut WorkingSet::new(ProverStorage::temporary());
+
+    accounts
+        .init_module(&account_config, native_working_set)
+        .unwrap();
+
+    let query_response: query::Response = serde_json::from_slice(
+        &accounts
+            .query(
+                QueryMessage::GetAccount(init_pub_key.clone()),
+                native_working_set,
+            )
+            .response,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query_response,
+        query::Response::AccountExists {
+            addr: init_pub_key_addr.as_ref().to_vec(),
+            nonce: 0
+        }
+    )
+}
+
+#[test]
 fn test_update_account() {
     let native_working_set = &mut WorkingSet::new(ProverStorage::temporary());
     let accounts = &mut Accounts::<C>::new();
-    let mut hooks = hooks::Hooks::<C>::new();
+    let hooks = hooks::Hooks::<C>::new();
 
     let sender = MockPublicKey::try_from("pub_key").unwrap();
     let sender_addr = sender.to_address::<<C as Spec>::Address>();
@@ -87,7 +122,7 @@ fn test_update_account() {
 fn test_update_account_fails() {
     let native_working_set = &mut WorkingSet::new(ProverStorage::temporary());
     let accounts = &mut Accounts::<C>::new();
-    let mut hooks = hooks::Hooks::<C>::new();
+    let hooks = hooks::Hooks::<C>::new();
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
     let sender_context_1 = C::new(sender_1.to_address());
@@ -116,7 +151,7 @@ fn test_update_account_fails() {
 fn test_get_acc_after_pub_key_update() {
     let native_working_set = &mut WorkingSet::new(ProverStorage::temporary());
     let accounts = &mut Accounts::<C>::new();
-    let mut hooks = hooks::Hooks::<C>::new();
+    let hooks = hooks::Hooks::<C>::new();
 
     let sender_1 = MockPublicKey::try_from("pub_key_1").unwrap();
     let sender_1_addr = sender_1.to_address::<<C as Spec>::Address>();

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -44,8 +44,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let (token_address, token) = Token::<C>::create(
-            token_name,
-            vec![(minter_address, initial_balance)],
+            &token_name,
+            &[(minter_address, initial_balance)],
             context.sender().as_ref(),
             salt,
             working_set,
@@ -56,7 +56,6 @@ impl<C: sov_modules_api::Context> Bank<C> {
         }
 
         self.tokens.set(&token_address, token, working_set);
-
         Ok(CallResponse::default())
     }
 

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -43,7 +43,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let token_address = super::create_token_address::<C>(&token_name, context.sender(), salt);
+        let token_address =
+            super::create_token_address::<C>(&token_name, context.sender().as_ref(), salt);
 
         if self.tokens.get(&token_address, working_set).is_some() {
             bail!("Token address already exists");
@@ -94,7 +95,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
-    fn prefix_from_address(&self, token_address: &C::Address) -> sov_state::Prefix {
+    pub(crate) fn prefix_from_address(&self, token_address: &C::Address) -> sov_state::Prefix {
         sov_state::Prefix::new(token_address.as_ref().to_vec())
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -43,24 +43,17 @@ impl<C: sov_modules_api::Context> Bank<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let token_address =
-            super::create_token_address::<C>(&token_name, context.sender().as_ref(), salt);
+        let (token_address, token) = Token::<C>::create(
+            token_name,
+            vec![(minter_address, initial_balance)],
+            context.sender().as_ref(),
+            salt,
+            working_set,
+        )?;
 
         if self.tokens.get(&token_address, working_set).is_some() {
             bail!("Token address already exists");
         }
-
-        let token_prefix = self.prefix_from_address(&token_address);
-
-        // Create balances map and initialize minter balance.
-        let balances = sov_state::StateMap::new(token_prefix);
-        balances.set(&minter_address, initial_balance, working_set);
-
-        let token = Token::<C> {
-            name: token_name,
-            total_supply: initial_balance,
-            balances,
-        };
 
         self.tokens.set(&token_address, token, working_set);
 
@@ -94,8 +87,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
     }
 }
 
-impl<C: sov_modules_api::Context> Bank<C> {
-    pub(crate) fn prefix_from_address(&self, token_address: &C::Address) -> sov_state::Prefix {
-        sov_state::Prefix::new(token_address.as_ref().to_vec())
-    }
+pub(crate) fn prefix_from_address<C: sov_modules_api::Context>(
+    token_address: &C::Address,
+) -> sov_state::Prefix {
+    sov_state::Prefix::new(token_address.as_ref().to_vec())
 }

--- a/sov-modules/sov-modules-impl/bank/src/create_token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/create_token.rs
@@ -3,11 +3,11 @@ use sov_modules_api::Hasher;
 /// Derives token address from `token_name`, `sender` and `salt`.
 pub fn create_token_address<C: sov_modules_api::Context>(
     token_name: &str,
-    sender_address: &C::Address,
+    sender: &[u8],
     salt: u64,
 ) -> C::Address {
     let mut hasher = C::Hasher::new();
-    hasher.update(sender_address.as_ref());
+    hasher.update(sender.as_ref());
     hasher.update(token_name.as_bytes());
     hasher.update(&salt.to_le_bytes());
 

--- a/sov-modules/sov-modules-impl/bank/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/bank/src/genesis.rs
@@ -1,10 +1,46 @@
-use crate::Bank;
-use anyhow::Result;
+use crate::{create_token_address, token::Token, Bank};
+use anyhow::{bail, Result};
 use sov_state::WorkingSet;
 
+pub const SALT: u64 = 0;
+pub const SENDER: [u8; 32] = [0; 32];
+
 impl<C: sov_modules_api::Context> Bank<C> {
-    pub(crate) fn init_module(&self, _working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
-        // TODO read initial tokens from "Config"
+    pub(crate) fn init_module(
+        &self,
+        config: &<Self as sov_modules_api::Module>::Config,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<()> {
+        let token_address = create_token_address::<C>(&config.token_name, &SENDER, SALT);
+
+        if self.tokens.get(&token_address, working_set).is_some() {
+            // `genesis` should run on an empty db, this is just a sanity check:
+            bail!("Impossible happened, token address already exists");
+        }
+
+        let token_prefix = self.prefix_from_address(&token_address);
+        let balances = sov_state::StateMap::new(token_prefix);
+
+        let mut total_supply: Option<u64> = Some(0);
+
+        for (address, balance) in config.address_and_balances.iter() {
+            balances.set(address, *balance, working_set);
+            total_supply = total_supply.and_then(|ts| ts.checked_add(*balance));
+        }
+
+        let total_supply = match total_supply {
+            Some(total_supply) => total_supply,
+            None => bail!("Total supply overflow"),
+        };
+
+        let token = Token::<C> {
+            name: config.token_name.clone(),
+            total_supply,
+            balances,
+        };
+
+        self.tokens.set(&token_address, token, working_set);
+
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/bank/src/genesis.rs
@@ -1,4 +1,4 @@
-use crate::{create_token_address, token::Token, Bank};
+use crate::{token::Token, Bank};
 use anyhow::{bail, Result};
 use sov_state::WorkingSet;
 
@@ -11,36 +11,21 @@ impl<C: sov_modules_api::Context> Bank<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        let token_address = create_token_address::<C>(&config.token_name, &SENDER, SALT);
+        for token_config in config.tokens.iter() {
+            let (token_address, token) = Token::<C>::create(
+                token_config.token_name.clone(),
+                token_config.address_and_balances.clone(),
+                &SENDER,
+                SALT,
+                working_set,
+            )?;
 
-        if self.tokens.get(&token_address, working_set).is_some() {
-            // `genesis` should run on an empty db, this is just a sanity check:
-            bail!("Impossible happened, token address already exists");
+            if self.tokens.get(&token_address, working_set).is_some() {
+                bail!("Impossible happened, token address already exists");
+            }
+
+            self.tokens.set(&token_address, token, working_set);
         }
-
-        let token_prefix = self.prefix_from_address(&token_address);
-        let balances = sov_state::StateMap::new(token_prefix);
-
-        let mut total_supply: Option<u64> = Some(0);
-
-        for (address, balance) in config.address_and_balances.iter() {
-            balances.set(address, *balance, working_set);
-            total_supply = total_supply.and_then(|ts| ts.checked_add(*balance));
-        }
-
-        let total_supply = match total_supply {
-            Some(total_supply) => total_supply,
-            None => bail!("Total supply overflow"),
-        };
-
-        let token = Token::<C> {
-            name: config.token_name.clone(),
-            total_supply,
-            balances,
-        };
-
-        self.tokens.set(&token_address, token, working_set);
-
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/bank/src/genesis.rs
@@ -13,15 +13,15 @@ impl<C: sov_modules_api::Context> Bank<C> {
     ) -> Result<()> {
         for token_config in config.tokens.iter() {
             let (token_address, token) = Token::<C>::create(
-                token_config.token_name.clone(),
-                token_config.address_and_balances.clone(),
+                &token_config.token_name,
+                &token_config.address_and_balances,
                 &SENDER,
                 SALT,
                 working_set,
             )?;
 
             if self.tokens.get(&token_address, working_set).is_some() {
-                bail!("Impossible happened, token address already exists");
+                bail!("Token address already exists");
             }
 
             self.tokens.set(&token_address, token, working_set);

--- a/sov-modules/sov-modules-impl/bank/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/bank/src/genesis.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Result};
 use sov_state::WorkingSet;
 
 pub const SALT: u64 = 0;
-pub const SENDER: [u8; 32] = [0; 32];
+pub const DEPLOYER: [u8; 32] = [0; 32];
 
 impl<C: sov_modules_api::Context> Bank<C> {
     pub(crate) fn init_module(
@@ -15,7 +15,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             let (token_address, token) = Token::<C>::create(
                 &token_config.token_name,
                 &token_config.address_and_balances,
-                &SENDER,
+                &DEPLOYER,
                 SALT,
                 working_set,
             )?;

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -14,10 +14,13 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
-pub struct BankConfig<C: sov_modules_api::Context> {
-    // TODO take collection of tokens
+pub struct TokenConfig<C: sov_modules_api::Context> {
     token_name: String,
     address_and_balances: Vec<(C::Address, u64)>,
+}
+
+pub struct BankConfig<C: sov_modules_api::Context> {
+    pub tokens: Vec<TokenConfig<C>>,
 }
 
 /// The Bank module manages user balances. It provides functionality for:

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -14,6 +14,12 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
+pub struct BankConfig<C: sov_modules_api::Context> {
+    // TODO take collection of tokens
+    token_name: String,
+    address_and_balances: Vec<(C::Address, u64)>,
+}
+
 /// The Bank module manages user balances. It provides functionality for:
 /// - Token creation.
 /// - Token transfers.
@@ -32,7 +38,7 @@ pub struct Bank<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
     type Context = C;
 
-    type Config = ();
+    type Config = BankConfig<C>;
 
     type CallMessage = call::CallMessage<C>;
 
@@ -40,10 +46,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
 
     fn genesis(
         &self,
-        _config: &Self::Config,
+        config: &Self::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(), Error> {
-        Ok(self.init_module(working_set)?)
+        Ok(self.init_module(config, working_set)?)
     }
 
     fn call(

--- a/sov-modules/sov-modules-impl/bank/src/lib.rs
+++ b/sov-modules/sov-modules-impl/bank/src/lib.rs
@@ -19,6 +19,7 @@ pub struct TokenConfig<C: sov_modules_api::Context> {
     address_and_balances: Vec<(C::Address, u64)>,
 }
 
+/// Initial configuration for Bank module.
 pub struct BankConfig<C: sov_modules_api::Context> {
     pub tokens: Vec<TokenConfig<C>>,
 }

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -144,7 +144,7 @@ fn create_test_bank() -> (TestBank, C) {
     let bank_config = create_bank_config(5);
     let init_token_address = create_token_address::<C>(
         &bank_config.tokens[0].token_name,
-        &genesis::SENDER,
+        &genesis::DEPLOYER,
         genesis::SALT,
     );
     (

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -1,6 +1,5 @@
 use crate::{
-    call, create_token_address,
-    genesis::{SALT, SENDER},
+    call, create_token_address, genesis,
     query::{self, QueryMessage},
     Bank, BankConfig, Coins, TokenConfig,
 };
@@ -143,8 +142,11 @@ fn create_test_bank() -> (TestBank, C) {
         super::create_token_address::<C>(&token_name, sender_address.as_ref(), salt);
 
     let bank_config = create_bank_config(5);
-    let init_token_address =
-        create_token_address::<C>(&bank_config.tokens[0].token_name, &SENDER, SALT);
+    let init_token_address = create_token_address::<C>(
+        &bank_config.tokens[0].token_name,
+        &genesis::SENDER,
+        genesis::SALT,
+    );
     (
         TestBank {
             bank,

--- a/sov-modules/sov-modules-impl/bank/src/tests.rs
+++ b/sov-modules/sov-modules-impl/bank/src/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     call, create_token_address,
     genesis::{SALT, SENDER},
     query::{self, QueryMessage},
-    Bank, BankConfig, Coins,
+    Bank, BankConfig, Coins, TokenConfig,
 };
 
 use sov_modules_api::{
@@ -114,9 +114,13 @@ fn create_bank_config(n: usize) -> BankConfig<C> {
         .map(|addr| (addr, 1000))
         .collect();
 
-    BankConfig {
+    let token_config = TokenConfig {
         token_name: "InitialToken".to_owned(),
         address_and_balances,
+    };
+
+    BankConfig {
+        tokens: vec![token_config],
     }
 }
 
@@ -139,7 +143,8 @@ fn create_test_bank() -> (TestBank, C) {
         super::create_token_address::<C>(&token_name, sender_address.as_ref(), salt);
 
     let bank_config = create_bank_config(5);
-    let init_token_address = create_token_address::<C>(&bank_config.token_name, &SENDER, SALT);
+    let init_token_address =
+        create_token_address::<C>(&bank_config.tokens[0].token_name, &SENDER, SALT);
     (
         TestBank {
             bank,
@@ -163,7 +168,7 @@ fn test_bank() {
     // Genesis
     {
         test_bank.genesis();
-        let (addr, balance) = test_bank.bank_config.address_and_balances[0].clone();
+        let (addr, balance) = test_bank.bank_config.tokens[0].address_and_balances[0].clone();
         let query_response = test_bank.query_balance_for_initial_token(addr);
 
         assert_eq!(query_response.amount, Some(balance));

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -2,6 +2,8 @@ use anyhow::{bail, Result};
 use sov_modules_api::CallResponse;
 use sov_state::WorkingSet;
 
+use crate::call::prefix_from_address;
+
 pub type Amount = u64;
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
@@ -54,5 +56,38 @@ impl<C: sov_modules_api::Context> Token<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         self.transfer(from, burn, amount, working_set)
+    }
+
+    pub(crate) fn create(
+        token_name: String,
+        address_and_balances: Vec<(C::Address, u64)>,
+        sender: &[u8],
+        salt: u64,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<(C::Address, Self)> {
+        let token_address = super::create_token_address::<C>(&token_name, sender, salt);
+
+        let token_prefix = prefix_from_address::<C>(&token_address);
+        let balances = sov_state::StateMap::new(token_prefix);
+
+        let mut total_supply: Option<u64> = Some(0);
+
+        for (address, balance) in address_and_balances.iter() {
+            balances.set(address, *balance, working_set);
+            total_supply = total_supply.and_then(|ts| ts.checked_add(*balance));
+        }
+
+        let total_supply = match total_supply {
+            Some(total_supply) => total_supply,
+            None => bail!("Total supply overflow"),
+        };
+
+        let token = Token::<C> {
+            name: token_name,
+            total_supply,
+            balances,
+        };
+
+        Ok((token_address, token))
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -59,13 +59,13 @@ impl<C: sov_modules_api::Context> Token<C> {
     }
 
     pub(crate) fn create(
-        token_name: String,
-        address_and_balances: Vec<(C::Address, u64)>,
+        token_name: &str,
+        address_and_balances: &[(C::Address, u64)],
         sender: &[u8],
         salt: u64,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(C::Address, Self)> {
-        let token_address = super::create_token_address::<C>(&token_name, sender, salt);
+        let token_address = super::create_token_address::<C>(token_name, sender, salt);
 
         let token_prefix = prefix_from_address::<C>(&token_address);
         let balances = sov_state::StateMap::new(token_prefix);
@@ -83,7 +83,7 @@ impl<C: sov_modules_api::Context> Token<C> {
         };
 
         let token = Token::<C> {
-            name: token_name,
+            name: token_name.to_owned(),
             total_supply,
             balances,
         };


### PR DESCRIPTION
This PR introduces the following changes:
1. Adds `genesis` tests in `Bank` & `Accounts` modules.
2. Refactor some common code to a separate place (for example token can be created via hook or in init.. method)