### PR TITLE
Add QueryResponse associated type to DispatchQuery

### DIFF
--- a/sov-modules/sov-modules-api/src/dispatch.rs
+++ b/sov-modules/sov-modules-api/src/dispatch.rs
@@ -1,4 +1,4 @@
-use crate::{CallResponse, Context, Error, QueryResponse, Spec};
+use crate::{CallResponse, Context, Error, Spec};
 use sov_state::WorkingSet;
 
 /// Methods from this trait should be called only once during the rollup deployment.
@@ -38,6 +38,7 @@ pub trait DispatchCall {
 pub trait DispatchQuery {
     type Context: Context;
     type Decodable;
+    type QueryResponse: core::fmt::Debug;
 
     /// Decode serialized query message
     fn decode_query(serialized_message: &[u8]) -> Result<Self::Decodable, std::io::Error>;
@@ -47,5 +48,5 @@ pub trait DispatchQuery {
         &self,
         message: Self::Decodable,
         working_set: &mut WorkingSet<<<Self as DispatchQuery>::Context as Spec>::Storage>,
-    ) -> QueryResponse;
+    ) -> Self::QueryResponse;
 }

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -139,6 +139,8 @@ pub trait Module {
 
     /// Module defined argument to the query method.
     type QueryMessage: Decode + Encode + Debug = NonInstantiable;
+    /// Module defined response to the query method.
+    type QueryResponse: Debug = QueryResponse;
 
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(
@@ -165,7 +167,7 @@ pub trait Module {
         &self,
         _message: Self::QueryMessage,
         _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> QueryResponse {
+    ) -> Self::QueryResponse {
         unreachable!()
     }
 }

--- a/sov-modules/sov-modules-impl/bank/src/query.rs
+++ b/sov-modules/sov-modules-impl/bank/src/query.rs
@@ -13,6 +13,16 @@ pub enum QueryMessage<C: sov_modules_api::Context> {
     GetTotalSupply { token_address: C::Address },
 }
 
+/// This enumeration represents the available query messages for querying the bank module.
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
+pub enum QueryResponse {
+    /// The balance of a specified token for a specified user.
+    /// This is non-optional, because all untouched accounts have a (well-defined) balance of 0.
+    GetBalance { balance: u64 },
+    /// The total supply of a requested token. This is optional, because because the total supply of an undefined token is undefined
+    GetTotalSupply { total_supply: Option<u64> },
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq)]
 pub struct BalanceResponse {
     pub amount: Option<Amount>,

--- a/sov-modules/sov-modules-macros/src/dispatch/common.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/common.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::{ToTokens, format_ident};
-use syn::{DataStruct, GenericParam, Generics, ImplGenerics, TypeGenerics, WhereClause, Meta};
+use quote::{format_ident, ToTokens};
+use syn::{DataStruct, GenericParam, Generics, ImplGenerics, Meta, TypeGenerics, WhereClause};
 
 #[derive(Clone)]
 pub(crate) struct StructNamedField {
@@ -66,6 +66,7 @@ impl StructFieldExtractor {
 
 pub(crate) const CALL: &str = "Call";
 pub(crate) const QUERY: &str = "Query";
+pub(crate) const QUERY_RESPONSE: &str = "QueryResponse";
 
 /// Represents "parsed" rust struct.
 pub(crate) struct StructDef<'a> {
@@ -101,16 +102,14 @@ impl<'a> StructDef<'a> {
         &self,
         enum_legs: &[proc_macro2::TokenStream],
         postfix: &'static str,
-        serialization_attrs: &Vec<TokenStream>
+        attrs: &Vec<TokenStream>,
     ) -> proc_macro2::TokenStream {
         let enum_ident = self.enum_ident(postfix);
         let impl_generics = &self.impl_generics;
         let where_clause = &self.where_clause;
 
         quote::quote! {
-            // This is generated code (won't be exposed to the users) and we allow non camel case for enum variants.
-            #[allow(non_camel_case_types)]
-            #[derive(::core::fmt::Debug, PartialEq, #(#serialization_attrs),*)]
+            #[derive(::core::fmt::Debug, #(#attrs),*)]
             pub (crate) enum #enum_ident #impl_generics #where_clause {
                 #(#enum_legs)*
             }
@@ -148,7 +147,11 @@ pub fn get_attribute_values(item: &syn::DeriveInput, attribute_name: &str) -> Ve
     let mut values = vec![];
 
     // Find the attribute with the given name on the root item
-    if let Some(attr) = item.attrs.iter().find(|attr| attr.path.is_ident(attribute_name)) {
+    if let Some(attr) = item
+        .attrs
+        .iter()
+        .find(|attr| attr.path.is_ident(attribute_name))
+    {
         if let Ok(meta) = attr.parse_meta() {
             if let Meta::List(list) = meta {
                 values.extend(list.nested.iter().map(|n| {
@@ -173,29 +176,28 @@ pub fn get_serialization_attrs(item: &syn::DeriveInput) -> Result<Vec<TokenStrea
     let mut has_deserialize = false;
     let mut has_other = false;
 
-    let attributes: Vec<String> = 
-        serialization_attrs.iter().map(|t| t.to_string()).collect();        
+    let attributes: Vec<String> = serialization_attrs.iter().map(|t| t.to_string()).collect();
 
-    for attr in &attributes {        
+    for attr in &attributes {
         if attr.contains(SERIALIZE) {
             has_serialize = true;
-        }
-        else if attr.contains(DESERIALIZE) {
+        } else if attr.contains(DESERIALIZE) {
             has_deserialize = true;
-        }
-        else {
+        } else {
             has_other = true;
         }
     }
 
     let tokens: TokenStream = quote::quote! { serialization };
-    if !has_serialize || !has_deserialize {        
+    if !has_serialize || !has_deserialize {
         return Err(syn::Error::new_spanned(
             &tokens,
-            format!("Serialization attributes must contain both '{}' and '{}', but contains '{:?}'", SERIALIZE, DESERIALIZE, &attributes),
+            format!(
+                "Serialization attributes must contain both '{}' and '{}', but contains '{:?}'",
+                SERIALIZE, DESERIALIZE, &attributes
+            ),
         ));
-    }
-    else if has_other {
+    } else if has_other {
         return Err(syn::Error::new_spanned(
             &tokens,
             format!("Serialization attributes can not contain attributes that are not '{}' and '{}', but contains: '{:?}'", 

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -1,8 +1,10 @@
+use crate::dispatch::dispatch_query::convert_snake_case_to_upper_camel_case;
+
+use super::common::get_serialization_attrs;
 use super::common::parse_generic_params;
 use super::common::StructDef;
 use super::common::StructFieldExtractor;
 use super::common::CALL;
-use super::common::get_serialization_attrs;
 use syn::DeriveInput;
 
 impl<'a> StructDef<'a> {
@@ -10,7 +12,7 @@ impl<'a> StructDef<'a> {
         self.fields
             .iter()
             .map(|field| {
-                let name = &field.ident;
+                let name = convert_snake_case_to_upper_camel_case(&field.ident);
                 let ty = &field.ty;
 
                 quote::quote!(
@@ -25,22 +27,24 @@ impl<'a> StructDef<'a> {
         let type_generics = &self.type_generics;
 
         let match_legs = self.fields.iter().map(|field| {
-            let name = &field.ident;
+            let field_name = &field.ident;
+            let variant_name = convert_snake_case_to_upper_camel_case(field_name);
 
             quote::quote!(
-                #enum_ident::#name(message)=>{
-                    sov_modules_api::Module::call(&self.#name, message, context, working_set)
+                #enum_ident::#variant_name(message)=>{
+                    sov_modules_api::Module::call(&self.#field_name, message, context, working_set)
                 },
             )
         });
 
         let match_legs_address = self.fields.iter().map(|field| {
-            let name = &field.ident;
+            let field_name = &field.ident;
+            let variant_name = convert_snake_case_to_upper_camel_case(&field.ident);
             let ty = &field.ty;
 
             quote::quote!(
-                #enum_ident::#name(message)=>{
-                   <#ty as sov_modules_api::ModuleInfo>::address(&self.#name)
+                #enum_ident::#variant_name(message)=>{
+                   <#ty as sov_modules_api::ModuleInfo>::address(&self.#field_name)
                 },
             )
         });

--- a/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/dispatch_query.rs
@@ -1,12 +1,37 @@
-use super::common::{parse_generic_params, StructDef, StructFieldExtractor, QUERY, get_serialization_attrs};
+use super::common::{
+    get_serialization_attrs, parse_generic_params, StructDef, StructFieldExtractor, QUERY,
+    QUERY_RESPONSE,
+};
+use proc_macro2::Ident;
+use quote::format_ident;
 use syn::DeriveInput;
 
+/// A handy function that gpt4 generated to convert snake-case identifiers to camel-case
+pub(crate) fn convert_snake_case_to_upper_camel_case(ident: &Ident) -> Ident {
+    let snake_case_str = ident.to_string();
+    let mut upper_camel_case_str = String::new();
+    let mut capitalize_next = true;
+
+    for ch in snake_case_str.chars() {
+        if ch == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            upper_camel_case_str.extend(ch.to_uppercase());
+            capitalize_next = false;
+        } else {
+            upper_camel_case_str.push(ch);
+        }
+    }
+
+    format_ident!("{}", upper_camel_case_str)
+}
+
 impl<'a> StructDef<'a> {
-    fn create_query_enum_legs(&self) -> Vec<proc_macro2::TokenStream> {
+    fn create_query_message_enum_legs(&self) -> Vec<proc_macro2::TokenStream> {
         self.fields
             .iter()
             .map(|field| {
-                let name = &field.ident;
+                let name = convert_snake_case_to_upper_camel_case(&field.ident);
                 let ty = &field.ty;
 
                 quote::quote!(
@@ -16,17 +41,33 @@ impl<'a> StructDef<'a> {
             .collect()
     }
 
+    fn create_query_response_enum_legs(&self) -> Vec<proc_macro2::TokenStream> {
+        self.fields
+            .iter()
+            .map(|field| {
+                let name = convert_snake_case_to_upper_camel_case(&field.ident);
+                let ty = &field.ty;
+
+                quote::quote!(
+                    #name(<#ty as sov_modules_api::Module>::QueryResponse),
+                )
+            })
+            .collect()
+    }
+
     /// Implements `sov_modules_api::DispatchQuery` for the enumeration created by `create_enum`.
     fn create_query_dispatch(&self) -> proc_macro2::TokenStream {
-        let enum_ident = &self.enum_ident(QUERY);
+        let query_enum_ident = &self.enum_ident(QUERY);
+        let query_response_enum_ident = &self.enum_ident(QUERY_RESPONSE);
         let type_generics = &self.type_generics;
 
         let match_legs = self.fields.iter().map(|field| {
-            let name = &field.ident;
+            let field_name = &field.ident;
+            let variant_name = convert_snake_case_to_upper_camel_case(&field.ident);
 
             quote::quote!(
-                #enum_ident::#name(message)=>{
-                    sov_modules_api::Module::query(&self.#name, message, working_set)
+                #query_enum_ident::#variant_name(message)=>{
+                    #query_response_enum_ident::#variant_name(sov_modules_api::Module::query(&self.#field_name, message, working_set))
                 },
             )
         });
@@ -36,23 +77,23 @@ impl<'a> StructDef<'a> {
         let where_clause = self.where_clause;
         let generic_param = self.generic_param;
         let ty_generics = &self.type_generics;
-        let query_enum = self.enum_ident(QUERY);
 
         quote::quote! {
             impl #impl_generics sov_modules_api::DispatchQuery for #ident #type_generics #where_clause{
                 type Context = #generic_param;
-                type Decodable = #query_enum #ty_generics;
+                type Decodable = #query_enum_ident #ty_generics;
+                type QueryResponse = #query_response_enum_ident #ty_generics;
 
                 fn decode_query(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
                     let mut data = std::io::Cursor::new(serialized_message);
-                    <#query_enum #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)
+                    <#query_enum_ident #ty_generics as sovereign_sdk::serial::Decode>::decode(&mut data)
                 }
 
                 fn dispatch_query(
                     &self,
                     decodable: Self::Decodable,
                     working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>
-                ) -> sov_modules_api::QueryResponse {
+                ) -> Self::QueryResponse {
 
                     match decodable {
                         #(#match_legs)*
@@ -101,12 +142,23 @@ impl DispatchQueryMacro {
             where_clause,
         );
 
-        let query_enum_legs = struct_def.create_query_enum_legs();
-        let query_enum = struct_def.create_enum(&query_enum_legs, QUERY, &serialization_methods);
+        let query_enum_legs = struct_def.create_query_message_enum_legs();
+        let query_response_enum_legs = struct_def.create_query_response_enum_legs();
+        let mut query_enum_attrs = serialization_methods.clone();
+        query_enum_attrs.push(quote::quote!(PartialEq));
+        let query_enum = struct_def.create_enum(&query_enum_legs, QUERY, &query_enum_attrs);
         let create_dispatch_impl = struct_def.create_query_dispatch();
+
+        let query_response_enum = struct_def.create_enum(
+            &query_response_enum_legs,
+            QUERY_RESPONSE,
+            &serialization_methods,
+        );
 
         Ok(quote::quote! {
             #query_enum
+
+            #query_response_enum
 
             #create_dispatch_impl
         }

--- a/sov-modules/sov-modules-macros/src/dispatch/message_codec.rs
+++ b/sov-modules/sov-modules-macros/src/dispatch/message_codec.rs
@@ -1,3 +1,5 @@
+use crate::dispatch::dispatch_query::convert_snake_case_to_upper_camel_case;
+
 use super::common::{parse_generic_params, StructDef, StructFieldExtractor, CALL, QUERY};
 use proc_macro2::TokenStream;
 use quote::format_ident;
@@ -10,7 +12,7 @@ impl<'a> StructDef<'a> {
         let ty_generics = &self.type_generics;
 
         let fns = self.fields.iter().map(|field| {
-            let variant = &field.ident;
+            let variant = convert_snake_case_to_upper_camel_case(&field.ident);
             let ty = &field.ty;
 
             let fn_call_name = format_ident!("encode_{}_call", &field.ident);


### PR DESCRIPTION
This commit implements four changes related to exposing typed data from the query apis (rather than just JSON strings, as in the current implementation):
1. Add DispatchQuery::QueryResponse type
2. Adjust the derive macros to handle the new associated type
3. Change the return type of the Bank::query to a new enum using the associated type
4. Adjust the derive macros to generate enums with proper casing