### PR TITLE
Test for Tx revert functionality in demo-app. 

### DIFF
--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -202,6 +202,11 @@ impl QueryGenerator {
         Runtime::<MockContext>::encode_election_query(query_message)
     }
 
+    pub(crate) fn generate_query_election_nb_of_votes_message() -> Vec<u8> {
+        let query_message = election::query::QueryMessage::GenNbOfVotes;
+        Runtime::<MockContext>::encode_election_query(query_message)
+    }
+
     pub(crate) fn generate_query_value_setter_message() -> Vec<u8> {
         let query_message = value_setter::query::QueryMessage::GetValue;
         Runtime::<MockContext>::encode_value_setter_query(query_message)

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -129,7 +129,7 @@ impl CallGenerator {
         let create_voter_messages = self.create_voters_and_vote();
         messages.extend(create_voter_messages.into_iter());
 
-        // This voter already voted
+        // Invalid message: This voter already voted.
         {
             let voter = MockPublicKey::try_from("voter_1").unwrap();
             let vote_message = election::call::CallMessage::Vote(1);

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -7,27 +7,55 @@ use sov_modules_api::mocks::{MockContext, MockPublicKey, MockSignature};
 use sov_modules_api::PublicKey;
 
 pub(crate) fn simulate_da() -> Vec<RawTx> {
+    let call_generator = &mut CallGenerator::new();
     let mut messages = Vec::default();
-    messages.extend(CallGenerator::election_call_messages());
-    messages.extend(CallGenerator::value_setter_call_messages());
+    messages.extend(call_generator.election_call_messages());
+    messages.extend(call_generator.value_setter_call_messages());
+    messages
+}
+
+pub(crate) fn simulate_da_with_revert_msg() -> Vec<RawTx> {
+    let call_generator = &mut CallGenerator::new();
+    let mut messages = Vec::default();
+    messages.extend(call_generator.election_call_messages_with_revert());
+
     messages
 }
 
 // Test helpers
-struct CallGenerator {}
+
+struct CallGenerator {
+    election_admin_nonce: u64,
+    election_admin: MockPublicKey,
+    value_setter_admin_nonce: u64,
+    value_setter_admin: MockPublicKey,
+}
 
 impl CallGenerator {
-    fn election_call_messages() -> Vec<RawTx> {
-        let mut messages = Vec::default();
+    fn new() -> Self {
+        Self {
+            election_admin_nonce: 0,
+            election_admin: MockPublicKey::try_from("election_admin").unwrap(),
+            value_setter_admin_nonce: 0,
+            value_setter_admin: MockPublicKey::try_from("value_setter_admin").unwrap(),
+        }
+    }
 
-        let admin = MockPublicKey::try_from("election_admin").unwrap();
+    fn create_voters_and_vote(
+        &mut self,
+    ) -> Vec<(MockPublicKey, election::call::CallMessage<MockContext>, u64)> {
+        let mut messages = Vec::default();
 
         let set_candidates_message = election::call::CallMessage::SetCandidates {
             names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
         };
 
-        let mut admin_nonce = 0;
-        messages.push((admin.clone(), set_candidates_message, admin_nonce));
+        messages.push((
+            self.election_admin.clone(),
+            set_candidates_message,
+            self.election_admin_nonce,
+        ));
+        self.election_admin_nonce += 1;
 
         let voters = vec![
             MockPublicKey::try_from("voter_1").unwrap(),
@@ -36,18 +64,50 @@ impl CallGenerator {
         ];
 
         for voter in voters {
-            admin_nonce += 1;
             let add_voter_message = election::call::CallMessage::AddVoter(voter.to_address());
 
-            messages.push((admin.clone(), add_voter_message, admin_nonce));
+            messages.push((
+                self.election_admin.clone(),
+                add_voter_message,
+                self.election_admin_nonce,
+            ));
 
             let vote_message = election::call::CallMessage::Vote(1);
             messages.push((voter, vote_message, 0));
+            self.election_admin_nonce += 1;
         }
 
-        admin_nonce += 1;
+        messages
+    }
+
+    fn freeze_vote(
+        &mut self,
+    ) -> Vec<(MockPublicKey, election::call::CallMessage<MockContext>, u64)> {
+        let mut messages = Vec::default();
+
         let freeze_message = election::call::CallMessage::FreezeElection;
-        messages.push((admin, freeze_message, admin_nonce));
+        messages.push((
+            self.election_admin.clone(),
+            freeze_message,
+            self.election_admin_nonce,
+        ));
+        self.election_admin_nonce += 1;
+
+        messages
+    }
+
+    fn election_call_messages(&mut self) -> Vec<RawTx> {
+        let mut messages = Vec::default();
+
+        {
+            let create_voter_messages = self.create_voters_and_vote();
+            messages.extend(create_voter_messages.into_iter());
+        }
+
+        {
+            let freeze_vote_messages = self.freeze_vote();
+            messages.extend(freeze_vote_messages.into_iter());
+        }
 
         messages
             .into_iter()
@@ -64,8 +124,40 @@ impl CallGenerator {
             .collect()
     }
 
-    fn value_setter_call_messages() -> Vec<RawTx> {
-        let admin = MockPublicKey::try_from("value_setter_admin").unwrap();
+    fn election_call_messages_with_revert(&mut self) -> Vec<RawTx> {
+        let mut messages = Vec::default();
+        let create_voter_messages = self.create_voters_and_vote();
+        messages.extend(create_voter_messages.into_iter());
+
+        // This voter already voted
+        {
+            let voter = MockPublicKey::try_from("voter_1").unwrap();
+            let vote_message = election::call::CallMessage::Vote(1);
+            messages.push((voter, vote_message, 1));
+        }
+
+        {
+            let freeze_vote_messages = self.freeze_vote();
+            messages.extend(freeze_vote_messages.into_iter());
+        }
+        messages
+            .into_iter()
+            .map(|(sender, m, nonce)| RawTx {
+                data: Transaction::<MockContext>::new(
+                    Runtime::<MockContext>::encode_election_call(m),
+                    sender,
+                    MockSignature::default(),
+                    nonce,
+                )
+                .try_to_vec()
+                .unwrap(),
+            })
+            .collect()
+    }
+
+    fn value_setter_call_messages(&mut self) -> Vec<RawTx> {
+        let mut messages = Vec::default();
+
         let new_value = 99;
 
         let set_value_msg_1 =
@@ -75,28 +167,30 @@ impl CallGenerator {
         let set_value_msg_2 =
             value_setter::call::CallMessage::DoSetValue(value_setter::call::SetValue { new_value });
 
-        vec![
-            RawTx {
-                data: Transaction::<MockContext>::new(
-                    Runtime::<MockContext>::encode_value_setter_call(set_value_msg_1),
-                    admin.clone(),
-                    MockSignature::default(),
-                    0,
-                )
-                .try_to_vec()
-                .unwrap(),
-            },
-            RawTx {
-                data: Transaction::<MockContext>::new(
-                    Runtime::<MockContext>::encode_value_setter_call(set_value_msg_2),
-                    admin,
-                    MockSignature::default(),
-                    1,
-                )
-                .try_to_vec()
-                .unwrap(),
-            },
-        ]
+        messages.push(RawTx {
+            data: Transaction::<MockContext>::new(
+                Runtime::<MockContext>::encode_value_setter_call(set_value_msg_1),
+                self.value_setter_admin.clone(),
+                MockSignature::default(),
+                self.value_setter_admin_nonce,
+            )
+            .try_to_vec()
+            .unwrap(),
+        });
+
+        self.value_setter_admin_nonce += 1;
+        messages.push(RawTx {
+            data: Transaction::<MockContext>::new(
+                Runtime::<MockContext>::encode_value_setter_call(set_value_msg_2),
+                self.value_setter_admin.clone(),
+                MockSignature::default(),
+                self.value_setter_admin_nonce,
+            )
+            .try_to_vec()
+            .unwrap(),
+        });
+
+        messages
     }
 }
 

--- a/demo-app/src/lib.rs
+++ b/demo-app/src/lib.rs
@@ -1,0 +1,13 @@
+#[cfg(test)]
+mod data_generation;
+#[cfg(test)]
+mod helpers;
+mod runtime;
+#[cfg(test)]
+mod test_utils;
+#[cfg(test)]
+mod tests;
+mod tx_hooks_impl;
+#[cfg(test)]
+mod tx_revert_tests;
+mod tx_verifier_impl;

--- a/demo-app/src/lib.rs
+++ b/demo-app/src/lib.rs
@@ -2,6 +2,7 @@
 mod data_generation;
 #[cfg(test)]
 mod helpers;
+#[cfg(test)]
 mod runtime;
 #[cfg(test)]
 mod test_utils;

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -1,8 +1,9 @@
 mod data_generation;
 mod helpers;
 mod runtime;
-
 mod tx_hooks_impl;
+#[cfg(test)]
+mod tx_revert_tests;
 mod tx_verifier_impl;
 
 use std::path::Path;

--- a/demo-app/src/test_utils.rs
+++ b/demo-app/src/test_utils.rs
@@ -1,0 +1,69 @@
+use crate::runtime::{GenesisConfig, Runtime};
+use crate::tx_hooks_impl::DemoAppTxHooks;
+use crate::tx_verifier_impl::DemoAppTxVerifier;
+use sov_app_template::AppTemplate;
+use sov_modules_api::{mocks::MockContext, PublicKey, Spec};
+use sov_state::ProverStorage;
+use std::path::Path;
+
+pub(crate) type C = MockContext;
+pub(crate) type DemoApp =
+    AppTemplate<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>, GenesisConfig<C>>;
+
+pub(crate) const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
+pub(crate) const LOCKED_AMOUNT: u64 = 200;
+pub(crate) const SEQ_PUB_KEY_STR: &str = "seq_pub_key";
+pub(crate) const TOKEN_NAME: &str = "Token0";
+
+pub(crate) fn create_sequencer_config(
+    seq_rollup_address: <C as Spec>::Address,
+    token_address: <C as Spec>::Address,
+) -> sequencer::SequencerConfig<C> {
+    sequencer::SequencerConfig {
+        seq_rollup_address,
+        seq_da_address: SEQUENCER_DA_ADDRESS.to_vec(),
+        coins_to_lock: bank::Coins {
+            amount: LOCKED_AMOUNT,
+            token_address,
+        },
+    }
+}
+
+pub(crate) fn create_config(initial_sequencer_balance: u64) -> GenesisConfig<C> {
+    let pub_key = <C as Spec>::PublicKey::try_from(SEQ_PUB_KEY_STR).unwrap();
+    let seq_address = pub_key.to_address::<<C as Spec>::Address>();
+
+    let token_config = bank::TokenConfig {
+        token_name: TOKEN_NAME.to_owned(),
+        address_and_balances: vec![(seq_address.clone(), initial_sequencer_balance)],
+    };
+
+    let bank_config = bank::BankConfig {
+        tokens: vec![token_config],
+    };
+
+    let token_address = bank::create_token_address::<C>(
+        &bank_config.tokens[0].token_name,
+        &bank::genesis::DEPLOYER,
+        bank::genesis::SALT,
+    );
+
+    let sequencer_config = create_sequencer_config(seq_address, token_address);
+
+    GenesisConfig::new(
+        sequencer_config,
+        bank_config,
+        (),
+        (),
+        accounts::AccountConfig { pub_keys: vec![] },
+    )
+}
+
+pub(crate) fn create_new_demo(initial_sequencer_balance: u64, path: impl AsRef<Path>) -> DemoApp {
+    let runtime = Runtime::new();
+    let storage = ProverStorage::with_path(path).unwrap();
+    let tx_hooks = DemoAppTxHooks::new();
+    let tx_verifier = DemoAppTxVerifier::new();
+    let genesis_config = create_config(initial_sequencer_balance);
+    AppTemplate::new(storage, runtime, tx_verifier, tx_hooks, genesis_config)
+}

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -1,126 +1,17 @@
-mod data_generation;
-mod helpers;
-mod runtime;
-mod tx_hooks_impl;
-#[cfg(test)]
-mod tx_revert_tests;
-mod tx_verifier_impl;
-
-use std::path::Path;
-
-use data_generation::{simulate_da, QueryGenerator};
-use helpers::check_query;
-use runtime::{GenesisConfig, Runtime};
-
-use sov_modules_api::{mocks::MockContext, PublicKey, Spec};
-use sov_state::ProverStorage;
-use sovereign_sdk::stf::StateTransitionFunction;
-
-use sov_app_template::{AppTemplate, Batch};
-use tx_hooks_impl::DemoAppTxHooks;
-use tx_verifier_impl::DemoAppTxVerifier;
-
-type C = MockContext;
-type DemoApp =
-    AppTemplate<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>, GenesisConfig<C>>;
-
-const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
-const LOCKED_AMOUNT: u64 = 200;
-const SEQ_PUB_KEY_STR: &str = "seq_pub_key";
-const TOKEN_NAME: &str = "Token0";
-
-fn create_sequencer_config(
-    seq_rollup_address: <C as Spec>::Address,
-    token_address: <C as Spec>::Address,
-) -> sequencer::SequencerConfig<C> {
-    sequencer::SequencerConfig {
-        seq_rollup_address,
-        seq_da_address: SEQUENCER_DA_ADDRESS.to_vec(),
-        coins_to_lock: bank::Coins {
-            amount: LOCKED_AMOUNT,
-            token_address,
-        },
-    }
-}
-
-fn create_config(initial_sequencer_balance: u64) -> GenesisConfig<C> {
-    let pub_key = <C as Spec>::PublicKey::try_from(SEQ_PUB_KEY_STR).unwrap();
-    let seq_address = pub_key.to_address::<<C as Spec>::Address>();
-
-    let token_config = bank::TokenConfig {
-        token_name: TOKEN_NAME.to_owned(),
-        address_and_balances: vec![(seq_address.clone(), initial_sequencer_balance)],
-    };
-
-    let bank_config = bank::BankConfig {
-        tokens: vec![token_config],
-    };
-
-    let token_address = bank::create_token_address::<C>(
-        &bank_config.tokens[0].token_name,
-        &bank::genesis::DEPLOYER,
-        bank::genesis::SALT,
-    );
-
-    let sequencer_config = create_sequencer_config(seq_address, token_address);
-
-    GenesisConfig::new(
-        sequencer_config,
-        bank_config,
-        (),
-        (),
-        accounts::AccountConfig { pub_keys: vec![] },
-    )
-}
-
-fn create_new_demo(initial_sequencer_balance: u64, path: impl AsRef<Path>) -> DemoApp {
-    let runtime = Runtime::new();
-    let storage = ProverStorage::with_path(path).unwrap();
-    let tx_hooks = DemoAppTxHooks::new();
-    let tx_verifier = DemoAppTxVerifier::new();
-    let genesis_config = create_config(initial_sequencer_balance);
-    AppTemplate::new(storage, runtime, tx_verifier, tx_hooks, genesis_config)
-}
-
-fn main() {
-    let path = schemadb::temppath::TempPath::new();
-    {
-        let mut demo = create_new_demo(LOCKED_AMOUNT + 1, &path);
-        demo.init_chain(());
-        demo.begin_slot();
-
-        let txs = simulate_da();
-
-        demo.apply_batch(Batch { txs }, &SEQUENCER_DA_ADDRESS, None)
-            .expect("Batch is valid");
-
-        demo.end_slot();
-    }
-
-    // Checks
-    {
-        let runtime = &mut Runtime::<MockContext>::new();
-        let storage = ProverStorage::with_path(&path).unwrap();
-        check_query(
-            runtime,
-            QueryGenerator::generate_query_election_message(),
-            r#"{"Result":{"name":"candidate_2","count":3}}"#,
-            storage.clone(),
-        );
-
-        check_query(
-            runtime,
-            QueryGenerator::generate_query_value_setter_message(),
-            r#"{"value":33}"#,
-            storage,
-        );
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use sov_app_template::Batch;
+    use sov_modules_api::mocks::MockContext;
+    use sov_state::ProverStorage;
+    use sovereign_sdk::stf::StateTransitionFunction;
 
-    use super::*;
+    use crate::{
+        data_generation::{simulate_da, QueryGenerator},
+        helpers::check_query,
+        runtime::Runtime,
+        test_utils::{create_new_demo, C, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
+    };
+
     #[test]
     fn test_demo_values_in_db() {
         let path = schemadb::temppath::TempPath::new();

--- a/demo-app/src/tx_hooks_impl.rs
+++ b/demo-app/src/tx_hooks_impl.rs
@@ -28,6 +28,7 @@ pub(crate) struct DemoAppTxHooks<C: Context> {
 }
 
 impl<C: Context> DemoAppTxHooks<C> {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             accounts_hooks: accounts::hooks::Hooks::<C>::new(),

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,0 +1,25 @@
+use crate::{create_new_demo, data_generation::simulate_da_with_revert_msg};
+use sov_app_template::{AppTemplate, Batch};
+use sovereign_sdk::stf::StateTransitionFunction;
+
+const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
+const LOCKED_AMOUNT: u64 = 200;
+/*
+#[test]
+fn test_tx_revert() {
+    let path = schemadb::temppath::TempPath::new();
+    {
+        let mut demo = create_new_demo(LOCKED_AMOUNT + 1, &path);
+
+        demo.init_chain(());
+        demo.begin_slot();
+
+        let txs = simulate_da_with_revert_msg();
+
+        demo.apply_batch(Batch { txs }, &SEQUENCER_DA_ADDRESS, None)
+            .expect("Batch is valid");
+
+        demo.end_slot();
+    }
+}
+*/

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -33,6 +33,8 @@ fn test_tx_revert() {
     {
         let runtime = &mut Runtime::<MockContext>::new();
         let storage = ProverStorage::with_path(&path).unwrap();
+
+        // We sent 4 vote messages but one of them is invalid and should be reverted.
         check_query(
             runtime,
             QueryGenerator::generate_query_election_nb_of_votes_message(),

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,8 +1,8 @@
 use crate::{
-    create_new_demo,
     data_generation::{simulate_da_with_revert_msg, QueryGenerator},
     helpers::check_query,
     runtime::Runtime,
+    test_utils::create_new_demo,
 };
 use sov_app_template::Batch;
 use sov_modules_api::mocks::MockContext;

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -2,15 +2,12 @@ use crate::{
     data_generation::{simulate_da_with_revert_msg, QueryGenerator},
     helpers::check_query,
     runtime::Runtime,
-    test_utils::create_new_demo,
+    test_utils::{create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
 };
 use sov_app_template::Batch;
 use sov_modules_api::mocks::MockContext;
 use sov_state::ProverStorage;
 use sovereign_sdk::stf::StateTransitionFunction;
-
-const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
-const LOCKED_AMOUNT: u64 = 200;
 
 #[test]
 fn test_tx_revert() {

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,10 +1,17 @@
-use crate::{create_new_demo, data_generation::simulate_da_with_revert_msg};
-use sov_app_template::{AppTemplate, Batch};
+use crate::{
+    create_new_demo,
+    data_generation::{simulate_da_with_revert_msg, QueryGenerator},
+    helpers::check_query,
+    runtime::Runtime,
+};
+use sov_app_template::Batch;
+use sov_modules_api::mocks::MockContext;
+use sov_state::ProverStorage;
 use sovereign_sdk::stf::StateTransitionFunction;
 
 const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
 const LOCKED_AMOUNT: u64 = 200;
-/*
+
 #[test]
 fn test_tx_revert() {
     let path = schemadb::temppath::TempPath::new();
@@ -21,5 +28,23 @@ fn test_tx_revert() {
 
         demo.end_slot();
     }
+
+    // Checks
+    {
+        let runtime = &mut Runtime::<MockContext>::new();
+        let storage = ProverStorage::with_path(&path).unwrap();
+        check_query(
+            runtime,
+            QueryGenerator::generate_query_election_nb_of_votes_message(),
+            r#"{"Result":3}"#,
+            storage.clone(),
+        );
+
+        check_query(
+            runtime,
+            QueryGenerator::generate_query_election_message(),
+            r#"{"Result":{"name":"candidate_2","count":3}}"#,
+            storage,
+        );
+    }
 }
-*/

--- a/demo-app/src/tx_verifier_impl.rs
+++ b/demo-app/src/tx_verifier_impl.rs
@@ -14,6 +14,7 @@ pub(crate) struct Transaction<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> Transaction<C> {
+    #[allow(dead_code)]
     pub fn new(msg: Vec<u8>, pub_key: C::PublicKey, signature: C::Signature, nonce: u64) -> Self {
         Self {
             signature,
@@ -29,6 +30,7 @@ pub(crate) struct DemoAppTxVerifier<C: Context> {
 }
 
 impl<C: Context> DemoAppTxVerifier<C> {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -158,7 +158,7 @@ where
                             batch_workspace = batch_workspace.commit();
                         }
                         Err(e) => {
-                            self.revert_and_slash(batch_workspace);
+                            //    self.revert_and_slash(batch_workspace);
                             panic!("Demo app txs must succeed but failed with err: {}", e)
                         }
                     }

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -158,6 +158,8 @@ where
                             batch_workspace = batch_workspace.commit();
                         }
                         Err(_e) => {
+                            // The transaction causing invalid state transition is reverted but we don't slash and we continue
+                            // processing remaining transactions.
                             batch_workspace = batch_workspace.revert();
                         }
                     }

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -158,8 +158,9 @@ where
                             batch_workspace = batch_workspace.commit();
                         }
                         Err(e) => {
+                            println!("Error:{}", e);
                             //    self.revert_and_slash(batch_workspace);
-                            panic!("Demo app txs must succeed but failed with err: {}", e)
+                            batch_workspace = batch_workspace.revert();
                         }
                     }
                 }

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -157,9 +157,7 @@ where
                             events.push(resp.events);
                             batch_workspace = batch_workspace.commit();
                         }
-                        Err(e) => {
-                            println!("Error:{}", e);
-                            //    self.revert_and_slash(batch_workspace);
+                        Err(_e) => {
                             batch_workspace = batch_workspace.revert();
                         }
                     }

--- a/sov-modules/sov-modules-impl/examples/election/src/call.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/call.rs
@@ -63,10 +63,14 @@ impl<C: sov_modules_api::Context> Election<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        // TODO testing
-        let number_of_votes = self.number_of_votes.get(working_set).unwrap_or_default();
-        self.number_of_votes.set(number_of_votes + 1, working_set);
+        let new_number_of_votes = self
+            .number_of_votes
+            .get(working_set)
+            .unwrap_or_default()
+            .checked_add(1)
+            .ok_or(anyhow!("Vote count overflow"))?;
 
+        self.number_of_votes.set(new_number_of_votes, working_set);
         self.exit_if_frozen(working_set)?;
 
         let voter = self

--- a/sov-modules/sov-modules-impl/examples/election/src/call.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/call.rs
@@ -63,6 +63,10 @@ impl<C: sov_modules_api::Context> Election<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
+        // TODO testing
+        let number_of_votes = self.number_of_votes.get(working_set).unwrap_or_default();
+        self.number_of_votes.set(number_of_votes + 1, working_set);
+
         self.exit_if_frozen(working_set)?;
 
         let voter = self

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -37,6 +37,9 @@ pub struct Election<C: sov_modules_api::Context> {
 
     #[state]
     pub(crate) allowed_voters: sov_state::StateMap<C::Address, Voter>,
+
+    #[state]
+    pub(crate) number_of_votes: sov_state::StateValue<u64>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
@@ -90,6 +93,11 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
         match msg {
             Self::QueryMessage::GetResult => {
                 let response = serde_json::to_vec(&self.results(working_set)).unwrap();
+                sov_modules_api::QueryResponse { response }
+            }
+
+            query::QueryMessage::GenNbOfVotes => {
+                let response = serde_json::to_vec(&self.number_of_votes(working_set)).unwrap();
                 sov_modules_api::QueryResponse { response }
             }
         }

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Election<C: sov_modules_api::Context> {
     #[state]
     pub(crate) allowed_voters: sov_state::StateMap<C::Address, Voter>,
 
-    //  This is used for testing revert functionality in demo-app.
+    //  This is used for testing revert functionality in the demo-app.
     #[state]
     pub(crate) number_of_votes: sov_state::StateValue<u64>,
 }

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Election<C: sov_modules_api::Context> {
     #[state]
     pub(crate) allowed_voters: sov_state::StateMap<C::Address, Voter>,
 
+    //  This is used for testing revert functionality in demo-app.
     #[state]
     pub(crate) number_of_votes: sov_state::StateValue<u64>,
 }

--- a/sov-modules/sov-modules-impl/examples/election/src/query.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/query.rs
@@ -7,16 +7,22 @@ use sov_state::WorkingSet;
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub enum QueryMessage {
     GetResult,
+    GenNbOfVotes,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub enum Response {
+pub enum GetResultResponse {
     Result(Option<Candidate>),
     Err(String),
 }
 
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub enum GetNbOfVotesResponse {
+    Result(u64),
+}
+
 impl<C: sov_modules_api::Context> Election<C> {
-    pub fn results(&self, working_set: &mut WorkingSet<C::Storage>) -> Response {
+    pub fn results(&self, working_set: &mut WorkingSet<C::Storage>) -> GetResultResponse {
         let is_frozen = self.is_frozen.get(working_set).unwrap_or_default();
 
         if is_frozen {
@@ -27,9 +33,17 @@ impl<C: sov_modules_api::Context> Election<C> {
                 .into_iter()
                 .max_by(|c1, c2| c1.count.cmp(&c2.count));
 
-            Response::Result(candidate)
+            GetResultResponse::Result(candidate)
         } else {
-            Response::Err("Election is not frozen".to_owned())
+            GetResultResponse::Err("Election is not frozen".to_owned())
         }
+    }
+
+    pub fn number_of_votes(
+        &self,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> GetNbOfVotesResponse {
+        let number_of_votes = self.number_of_votes.get(working_set).unwrap_or_default();
+        GetNbOfVotesResponse::Result(number_of_votes)
     }
 }

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     call::CallMessage,
-    query::{QueryMessage, Response},
+    query::{GetResultResponse, QueryMessage},
     types::Candidate,
     Election,
 };
@@ -99,11 +99,11 @@ fn test_module<C: Context<PublicKey = MockPublicKey>>(working_set: &mut WorkingS
     {
         let query = QueryMessage::GetResult;
         let query = election.query(query, working_set);
-        let query_response: Response = serde_json::from_slice(&query.response).unwrap();
+        let query_response: GetResultResponse = serde_json::from_slice(&query.response).unwrap();
 
         assert_eq!(
             query_response,
-            Response::Result(Some(Candidate {
+            GetResultResponse::Result(Some(Candidate {
                 name: "candidate_2".to_owned(),
                 count: 2
             }))


### PR DESCRIPTION
This PR introduces the following changes:
1. Add tests for the revert functionality in the `demo-app`
2. Refactors `data_generation.rs` to be more modular (now we can generate invalid transactions)
3. Removes `main.rs` and replace it with `lib.rs`. We don't run the demo-app, and the main method was basically one of the unit tests. 