### PR TITLE
AppTemplate: tests for reverts & slashing.

### DIFF
--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -243,4 +243,9 @@ impl QueryGenerator {
         let query_message = value_setter::query::QueryMessage::GetValue;
         Runtime::<MockContext>::encode_value_setter_query(query_message)
     }
+
+    pub(crate) fn generate_query_check_balance() -> Vec<u8> {
+        let query_message = sequencer::query::QueryMessage::GetSequencerAddressAndBalance;
+        Runtime::<MockContext>::encode_sequencer_query(query_message)
+    }
 }

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -16,10 +16,12 @@ pub(crate) fn simulate_da() -> Vec<RawTx> {
 
 pub(crate) fn simulate_da_with_revert_msg() -> Vec<RawTx> {
     let call_generator = &mut CallGenerator::new();
-    let mut messages = Vec::default();
-    messages.extend(call_generator.election_call_messages_with_revert());
+    call_generator.election_call_messages_with_revert()
+}
 
-    messages
+pub(crate) fn simulate_da_with_bad_sig() -> Vec<RawTx> {
+    let call_generator = &mut CallGenerator::new();
+    call_generator.election_call_messages_bad_sig()
 }
 
 // Test helpers
@@ -153,6 +155,36 @@ impl CallGenerator {
                 .unwrap(),
             })
             .collect()
+    }
+
+    fn election_call_messages_bad_sig(&mut self) -> Vec<RawTx> {
+        let mut messages = Vec::default();
+        messages.extend(self.create_voters_and_vote());
+        messages.extend(self.freeze_vote());
+
+        let mut messages_iter = messages.into_iter().peekable();
+
+        let mut serialized_messages = Vec::default();
+        while let Some((sender, m, nonce)) = messages_iter.next() {
+            // The last message has bad signature.
+            let should_fail = messages_iter.peek().is_none();
+
+            serialized_messages.push(RawTx {
+                data: Transaction::<MockContext>::new(
+                    Runtime::<MockContext>::encode_election_call(m),
+                    sender,
+                    MockSignature {
+                        msg_sig: Vec::default(),
+                        should_fail,
+                    },
+                    nonce,
+                )
+                .try_to_vec()
+                .unwrap(),
+            });
+        }
+
+        serialized_messages
     }
 
     fn value_setter_call_messages(&mut self) -> Vec<RawTx> {

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -166,7 +166,7 @@ impl CallGenerator {
 
         let mut serialized_messages = Vec::default();
         while let Some((sender, m, nonce)) = messages_iter.next() {
-            // The last message has bad signature.
+            // The last message has a bad signature.
             let should_fail = messages_iter.peek().is_none();
 
             serialized_messages.push(RawTx {

--- a/demo-app/src/helpers.rs
+++ b/demo-app/src/helpers.rs
@@ -5,19 +5,6 @@ use std::str;
 
 use crate::runtime::Runtime;
 
-pub(crate) fn check_query(
-    runtime: &mut Runtime<MockContext>,
-    query: Vec<u8>,
-    expected_response: &str,
-    storage: ProverStorage<MockStorageSpec>,
-) {
-    let module = Runtime::<MockContext>::decode_query(&query).unwrap();
-    let query_response = runtime.dispatch_query(module, &mut WorkingSet::new(storage));
-
-    let response = str::from_utf8(&query_response.response).unwrap();
-    assert_eq!(response, expected_response)
-}
-
 pub(crate) fn query_and_deserialize<R: DeserializeOwned>(
     runtime: &mut Runtime<MockContext>,
     query: Vec<u8>,

--- a/demo-app/src/helpers.rs
+++ b/demo-app/src/helpers.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use sov_modules_api::{mocks::MockContext, DispatchQuery};
 use sov_state::{mocks::MockStorageSpec, ProverStorage, WorkingSet};
 use std::str;
@@ -15,4 +16,14 @@ pub(crate) fn check_query(
 
     let response = str::from_utf8(&query_response.response).unwrap();
     assert_eq!(response, expected_response)
+}
+
+pub(crate) fn query_and_deserialize<R: DeserializeOwned>(
+    runtime: &mut Runtime<MockContext>,
+    query: Vec<u8>,
+    storage: ProverStorage<MockStorageSpec>,
+) -> R {
+    let module = Runtime::<MockContext>::decode_query(&query).unwrap();
+    let query_response = runtime.dispatch_query(module, &mut WorkingSet::new(storage));
+    serde_json::from_slice(&query_response.response).expect("Failed to deserialize response json")
 }

--- a/demo-app/src/helpers.rs
+++ b/demo-app/src/helpers.rs
@@ -1,7 +1,6 @@
 use serde::de::DeserializeOwned;
 use sov_modules_api::{mocks::MockContext, DispatchQuery};
 use sov_state::{mocks::MockStorageSpec, ProverStorage, WorkingSet};
-use std::str;
 
 use crate::runtime::Runtime;
 

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -7,7 +7,7 @@ mod test {
 
     use crate::{
         data_generation::{simulate_da, QueryGenerator},
-        helpers::{check_query, query_and_deserialize},
+        helpers::query_and_deserialize,
         runtime::Runtime,
         test_utils::{create_new_demo, C, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
     };
@@ -48,12 +48,13 @@ mod test {
                 }))
             );
 
-            check_query(
+            let resp = query_and_deserialize::<value_setter::query::Response>(
                 runtime,
                 QueryGenerator::generate_query_value_setter_message(),
-                r#"{"value":33}"#,
                 storage,
             );
+
+            assert_eq!(resp, value_setter::query::Response { value: Some(33) });
         }
     }
 
@@ -86,12 +87,13 @@ mod test {
             }))
         );
 
-        check_query(
+        let resp = query_and_deserialize::<value_setter::query::Response>(
             runtime,
             QueryGenerator::generate_query_value_setter_message(),
-            r#"{"value":33}"#,
-            demo.current_storage,
+            demo.current_storage.clone(),
         );
+
+        assert_eq!(resp, value_setter::query::Response { value: Some(33) });
     }
 
     #[test]
@@ -124,12 +126,13 @@ mod test {
                 election::query::GetResultResponse::Err("Election is not frozen".to_owned())
             );
 
-            check_query(
+            let resp = query_and_deserialize::<value_setter::query::Response>(
                 runtime,
                 QueryGenerator::generate_query_value_setter_message(),
-                r#"{"value":null}"#,
                 storage,
             );
+
+            assert_eq!(resp, value_setter::query::Response { value: None });
         }
     }
 

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -32,18 +32,26 @@ fn test_tx_revert() {
         let storage = ProverStorage::with_path(&path).unwrap();
 
         // We sent 4 vote messages but one of them is invalid and should be reverted.
-        check_query(
+        let resp = query_and_deserialize::<election::query::GetNbOfVotesResponse>(
             runtime,
             QueryGenerator::generate_query_election_nb_of_votes_message(),
-            r#"{"Result":3}"#,
             storage.clone(),
         );
 
-        check_query(
+        assert_eq!(resp, election::query::GetNbOfVotesResponse::Result(3));
+
+        let resp = query_and_deserialize::<election::query::GetResultResponse>(
             runtime,
             QueryGenerator::generate_query_election_message(),
-            r#"{"Result":{"name":"candidate_2","count":3}}"#,
             storage,
+        );
+
+        assert_eq!(
+            resp,
+            election::query::GetResultResponse::Result(Some(election::Candidate {
+                name: "candidate_2".to_owned(),
+                count: 3
+            }))
         );
     }
 }

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     data_generation::{simulate_da_with_bad_sig, simulate_da_with_revert_msg, QueryGenerator},
-    helpers::{check_query, query_and_deserialize},
+    helpers::query_and_deserialize,
     runtime::Runtime,
     test_utils::{create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
 };

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -62,6 +62,7 @@ fn test_tx_revert() {
             storage,
         );
 
+        // Sequencer is rewarded
         assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE);
     }
 }
@@ -108,6 +109,7 @@ fn test_tx_bad_sig() {
             storage,
         );
 
+        // Sequencer is slashed
         assert_eq!(resp.data.unwrap().balance, 1);
     }
 }

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data_generation::{simulate_da_with_revert_msg, QueryGenerator},
+    data_generation::{simulate_da_with_bad_sig, simulate_da_with_revert_msg, QueryGenerator},
     helpers::check_query,
     runtime::Runtime,
     test_utils::{create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
@@ -43,6 +43,40 @@ fn test_tx_revert() {
             runtime,
             QueryGenerator::generate_query_election_message(),
             r#"{"Result":{"name":"candidate_2","count":3}}"#,
+            storage,
+        );
+    }
+}
+
+#[test]
+fn test_tx_bad_sig() {
+    let path = schemadb::temppath::TempPath::new();
+
+    {
+        let mut demo = create_new_demo(LOCKED_AMOUNT + 1, &path);
+
+        demo.init_chain(());
+        demo.begin_slot();
+
+        let txs = simulate_da_with_bad_sig();
+
+        let res = demo
+            .apply_batch(Batch { txs }, &SEQUENCER_DA_ADDRESS, None)
+            .unwrap_err();
+
+        assert_eq!(res.to_string(), "Stateless verification error - the sequencer included a transaction which was known to be invalid. Bad signature");
+
+        demo.end_slot();
+    }
+
+    {
+        let runtime = &mut Runtime::<MockContext>::new();
+        let storage = ProverStorage::with_path(&path).unwrap();
+
+        check_query(
+            runtime,
+            QueryGenerator::generate_query_election_message(),
+            r#"{"Err":"Election is not frozen"}"#,
             storage,
         );
     }

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -9,7 +9,8 @@ use sov_modules_api::mocks::MockContext;
 use sov_state::ProverStorage;
 use sovereign_sdk::stf::StateTransitionFunction;
 
-const SEQUENCER_BALANCE: u64 = LOCKED_AMOUNT + 1;
+const SEQUENCER_BALANCE_DELTA: u64 = 1;
+const SEQUENCER_BALANCE: u64 = LOCKED_AMOUNT + SEQUENCER_BALANCE_DELTA;
 
 #[test]
 fn test_tx_revert() {
@@ -110,6 +111,6 @@ fn test_tx_bad_sig() {
         );
 
         // Sequencer is slashed
-        assert_eq!(resp.data.unwrap().balance, 1);
+        assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE_DELTA);
     }
 }

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -9,11 +9,13 @@ use sov_modules_api::mocks::MockContext;
 use sov_state::ProverStorage;
 use sovereign_sdk::stf::StateTransitionFunction;
 
+const SEQUENCER_BALANCE: u64 = LOCKED_AMOUNT + 1;
+
 #[test]
 fn test_tx_revert() {
     let path = schemadb::temppath::TempPath::new();
     {
-        let mut demo = create_new_demo(LOCKED_AMOUNT + 1, &path);
+        let mut demo = create_new_demo(SEQUENCER_BALANCE, &path);
 
         demo.init_chain(());
         demo.begin_slot();
@@ -43,7 +45,7 @@ fn test_tx_revert() {
         let resp = query_and_deserialize::<election::query::GetResultResponse>(
             runtime,
             QueryGenerator::generate_query_election_message(),
-            storage,
+            storage.clone(),
         );
 
         assert_eq!(
@@ -53,6 +55,14 @@ fn test_tx_revert() {
                 count: 3
             }))
         );
+
+        let resp = query_and_deserialize::<sequencer::query::SequencerAndBalanceResponse>(
+            runtime,
+            QueryGenerator::generate_query_check_balance(),
+            storage,
+        );
+
+        assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE);
     }
 }
 
@@ -61,7 +71,7 @@ fn test_tx_bad_sig() {
     let path = schemadb::temppath::TempPath::new();
 
     {
-        let mut demo = create_new_demo(LOCKED_AMOUNT + 1, &path);
+        let mut demo = create_new_demo(SEQUENCER_BALANCE, &path);
 
         demo.init_chain(());
         demo.begin_slot();

--- a/demo-app/src/tx_verifier_impl.rs
+++ b/demo-app/src/tx_verifier_impl.rs
@@ -14,6 +14,7 @@ pub(crate) struct Transaction<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> Transaction<C> {
+    #[allow(dead_code)]
     pub fn new(msg: Vec<u8>, pub_key: C::PublicKey, signature: C::Signature, nonce: u64) -> Self {
         Self {
             signature,
@@ -29,6 +30,7 @@ pub(crate) struct DemoAppTxVerifier<C: Context> {
 }
 
 impl<C: Context> DemoAppTxVerifier<C> {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/demo-app/src/tx_verifier_impl.rs
+++ b/demo-app/src/tx_verifier_impl.rs
@@ -14,7 +14,6 @@ pub(crate) struct Transaction<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> Transaction<C> {
-    #[allow(dead_code)]
     pub fn new(msg: Vec<u8>, pub_key: C::PublicKey, signature: C::Signature, nonce: u64) -> Self {
         Self {
             signature,
@@ -30,7 +29,6 @@ pub(crate) struct DemoAppTxVerifier<C: Context> {
 }
 
 impl<C: Context> DemoAppTxVerifier<C> {
-    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/sov-modules/sov-modules-api/src/mocks.rs
+++ b/sov-modules/sov-modules-api/src/mocks.rs
@@ -19,7 +19,10 @@ impl MockPublicKey {
     }
 
     pub fn sign(&self, _msg: [u8; 32]) -> MockSignature {
-        MockSignature { msg_sig: vec![] }
+        MockSignature {
+            msg_sig: vec![],
+            should_fail: false,
+        }
     }
 }
 
@@ -52,6 +55,7 @@ impl PublicKey for MockPublicKey {
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct MockSignature {
     pub msg_sig: Vec<u8>,
+    pub should_fail: bool,
 }
 
 impl Signature for MockSignature {
@@ -62,7 +66,11 @@ impl Signature for MockSignature {
         _pub_key: &Self::PublicKey,
         _msg_hash: [u8; 32],
     ) -> Result<(), SigVerificationError> {
-        Ok(())
+        if self.should_fail {
+            Err(SigVerificationError::BadSignature)
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
This PR introduces the following changes:
1. Test assuring that the sequencer is slashed, if a tx with invalid signature is included in a batch.
2. Makes `MockSignature` configurable, now the `verify` method can fail
3. Replaces `check_query` with `query_and_deserialize`, now the values in tests are strongly typed. 