### PR TITLE
AppTemplate: Add more tests and improve tx revert functionality.

### DIFF
--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -237,6 +237,7 @@ impl CallGenerator {
 
         let mut serialized_messages = Vec::default();
         while let Some((sender, m, nonce)) = messages_iter.next() {
+            // The last message is misformatted.
             let call_data = if messages_iter.peek().is_none() {
                 vec![1, 2, 3]
             } else {

--- a/demo-app/src/data_generation.rs
+++ b/demo-app/src/data_generation.rs
@@ -24,6 +24,11 @@ pub(crate) fn simulate_da_with_bad_sig() -> Vec<RawTx> {
     call_generator.election_call_messages_bad_sig()
 }
 
+pub(crate) fn simulate_da_with_bad_nonce() -> Vec<RawTx> {
+    let call_generator = &mut CallGenerator::new();
+    call_generator.election_call_messages_bad_nonce()
+}
+
 // Test helpers
 
 struct CallGenerator {
@@ -177,6 +182,37 @@ impl CallGenerator {
                         msg_sig: Vec::default(),
                         should_fail,
                     },
+                    nonce,
+                )
+                .try_to_vec()
+                .unwrap(),
+            });
+        }
+
+        serialized_messages
+    }
+
+    fn election_call_messages_bad_nonce(&mut self) -> Vec<RawTx> {
+        let mut messages = Vec::default();
+        messages.extend(self.create_voters_and_vote());
+        messages.extend(self.freeze_vote());
+
+        let mut messages_iter = messages.into_iter().peekable();
+
+        let mut serialized_messages = Vec::default();
+        while let Some((sender, m, nonce)) = messages_iter.next() {
+            // The last message has a bad nonce.
+            let nonce = if messages_iter.peek().is_none() {
+                nonce + 1
+            } else {
+                nonce
+            };
+
+            serialized_messages.push(RawTx {
+                data: Transaction::<MockContext>::new(
+                    Runtime::<MockContext>::encode_election_call(m),
+                    sender,
+                    MockSignature::default(),
                     nonce,
                 )
                 .try_to_vec()

--- a/demo-app/src/tx_hooks_impl.rs
+++ b/demo-app/src/tx_hooks_impl.rs
@@ -85,13 +85,6 @@ impl<C: Context> TxHooks for DemoAppTxHooks<C> {
         self.sequencer_hooks.lock(working_set)
     }
 
-    fn post_revert_apply_batch(
-        &self,
-        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> Result<()> {
-        self.sequencer_hooks.lock(working_set)
-    }
-
     fn exit_apply_batch(
         &self,
         amount: u64,

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,5 +1,8 @@
 use crate::{
-    data_generation::{simulate_da_with_bad_sig, simulate_da_with_revert_msg, QueryGenerator},
+    data_generation::{
+        simulate_da_with_bad_nonce, simulate_da_with_bad_sig, simulate_da_with_revert_msg,
+        QueryGenerator,
+    },
     helpers::query_and_deserialize,
     runtime::Runtime,
     test_utils::{create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
@@ -112,5 +115,52 @@ fn test_tx_bad_sig() {
 
         // Sequencer is slashed
         assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE_DELTA);
+    }
+}
+
+#[test]
+fn test_tx_bad_nonce() {
+    let path = schemadb::temppath::TempPath::new();
+
+    {
+        let mut demo = create_new_demo(SEQUENCER_BALANCE, &path);
+
+        demo.init_chain(());
+        demo.begin_slot();
+
+        let txs = simulate_da_with_bad_nonce();
+
+        let res = demo
+            .apply_batch(Batch { txs }, &SEQUENCER_DA_ADDRESS, None)
+            .unwrap_err();
+
+        assert_eq!(res.to_string(), "Stateful verification error - the sequencer included an invalid transaction: Tx bad nonce, expected: 4, but found: 5");
+
+        demo.end_slot();
+    }
+
+    {
+        let runtime = &mut Runtime::<MockContext>::new();
+        let storage = ProverStorage::with_path(&path).unwrap();
+
+        let resp = query_and_deserialize::<election::query::GetResultResponse>(
+            runtime,
+            QueryGenerator::generate_query_election_message(),
+            storage.clone(),
+        );
+
+        assert_eq!(
+            resp,
+            election::query::GetResultResponse::Err("Election is not frozen".to_owned())
+        );
+
+        let resp = query_and_deserialize::<sequencer::query::SequencerAndBalanceResponse>(
+            runtime,
+            QueryGenerator::generate_query_check_balance(),
+            storage,
+        );
+
+        // Sequencer is rewarded
+        assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE);
     }
 }

--- a/sov-modules/sov-app-template/src/tx_hooks.rs
+++ b/sov-modules/sov-app-template/src/tx_hooks.rs
@@ -36,12 +36,6 @@ pub trait TxHooks {
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> Result<()>;
 
-    /// runs after batch reverts.
-    fn post_revert_apply_batch(
-        &self,
-        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> Result<()>;
-
     /// runs at the end of apply_batch.
     fn exit_apply_batch(
         &self,


### PR DESCRIPTION
This PR introduces the following changes:
1. Adds test for bad tx nonce
2. Adds tests for misformatted tx
3. Refactors `apply_batch` implementation:
 Now the sequencers locked coins are committed at the beginning of `apply_batch`.