### PR TITLE
Introduce dalek signature scheme

### DIFF
--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -160,11 +160,9 @@ pub fn generate_address(key: &str) -> <C as Spec>::Address {
 #[cfg(test)]
 pub(crate) fn create_config(
     initial_sequencer_balance: u64,
-) -> (
-    GenesisConfig<DefaultContext>,
-    DefaultPrivateKey,
-    DefaultPrivateKey,
-) {
+    value_setter_admin_private_key: &DefaultPrivateKey,
+    election_admin_private_key: &DefaultPrivateKey,
+) -> GenesisConfig<DefaultContext> {
     use election::ElectionConfig;
     use value_setter::ValueSetterConfig;
 
@@ -187,28 +185,20 @@ pub(crate) fn create_config(
 
     let sequencer_config = create_sequencer_config(seq_address, token_address);
 
-    let value_setter_admin_private_key = DefaultPrivateKey::generate();
-    let value_setter_admin_pub_key = value_setter_admin_private_key.pub_key();
     let value_setter_config = ValueSetterConfig {
-        admin: value_setter_admin_pub_key.to_address(),
+        admin: value_setter_admin_private_key.pub_key().to_address(),
     };
 
-    let election_admin_private_key = DefaultPrivateKey::generate();
-    let election_admin_pub_key = election_admin_private_key.pub_key();
     let election_config = ElectionConfig {
-        admin: election_admin_pub_key.to_address(),
+        admin: election_admin_private_key.pub_key().to_address(),
     };
 
-    (
-        GenesisConfig::new(
-            sequencer_config,
-            bank_config,
-            election_config,
-            value_setter_config,
-            accounts::AccountConfig { pub_keys: vec![] },
-        ),
-        value_setter_admin_private_key,
-        election_admin_private_key,
+    GenesisConfig::new(
+        sequencer_config,
+        bank_config,
+        election_config,
+        value_setter_config,
+        accounts::AccountConfig { pub_keys: vec![] },
     )
 }
 

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -1,14 +1,18 @@
-use crate::runtime::{GenesisConfig, Runtime};
+#[cfg(feature = "native")]
+use crate::runtime::GenesisConfig;
+use crate::runtime::Runtime;
 use crate::tx_hooks_impl::DemoAppTxHooks;
 use crate::tx_verifier_impl::DemoAppTxVerifier;
 use sov_app_template::AppTemplate;
 pub use sov_app_template::Batch;
 #[cfg(feature = "native")]
-use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
-use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
+use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 #[cfg(feature = "native")]
+use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::Context;
-use sov_modules_api::{Hasher, PublicKey, Spec};
+use sov_modules_api::PublicKey;
+use sov_modules_api::{Hasher, Spec};
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
 use sov_state::Storage;
@@ -80,6 +84,7 @@ impl StateTransitionRunner<ZkConfig> for DemoAppRunner<ZkDefaultContext> {
     }
 }
 
+#[cfg(feature = "native")]
 pub fn create_config(
     initial_sequencer_balance: u64,
     value_setter_admin_private_key: &DefaultPrivateKey,
@@ -94,6 +99,7 @@ pub fn create_config(
     )
 }
 
+#[cfg(feature = "native")]
 fn create_genesis_config<C: Context>(
     initial_sequencer_balance: u64,
     sequencer_address: C::Address,

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -165,6 +165,7 @@ pub(crate) fn create_config(
     DefaultPrivateKey,
     DefaultPrivateKey,
 ) {
+    use election::ElectionConfig;
     use value_setter::ValueSetterConfig;
 
     let seq_address = generate_address(SEQ_PUB_KEY_STR);
@@ -194,13 +195,15 @@ pub(crate) fn create_config(
 
     let election_admin_private_key = DefaultPrivateKey::generate();
     let election_admin_pub_key = election_admin_private_key.pub_key();
-    let election_admin_address: <C as Spec>::Address = election_admin_pub_key.to_address();
+    let election_config = ElectionConfig {
+        admin: election_admin_pub_key.to_address(),
+    };
 
     (
         GenesisConfig::new(
             sequencer_config,
             bank_config,
-            election_admin_address,
+            election_config,
             value_setter_config,
             accounts::AccountConfig { pub_keys: vec![] },
         ),

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -165,6 +165,8 @@ pub(crate) fn create_config(
     DefaultPrivateKey,
     DefaultPrivateKey,
 ) {
+    use value_setter::ValueSetterConfig;
+
     let seq_address = generate_address(SEQ_PUB_KEY_STR);
 
     let token_config: bank::TokenConfig<DefaultContext> = bank::TokenConfig {
@@ -186,7 +188,9 @@ pub(crate) fn create_config(
 
     let value_setter_admin_private_key = DefaultPrivateKey::generate();
     let value_setter_admin_pub_key = value_setter_admin_private_key.pub_key();
-    let value_setter_admin_address: <C as Spec>::Address = value_setter_admin_pub_key.to_address();
+    let value_setter_config = ValueSetterConfig {
+        admin: value_setter_admin_pub_key.to_address(),
+    };
 
     let election_admin_private_key = DefaultPrivateKey::generate();
     let election_admin_pub_key = election_admin_private_key.pub_key();
@@ -197,7 +201,7 @@ pub(crate) fn create_config(
             sequencer_config,
             bank_config,
             election_admin_address,
-            value_setter_admin_address,
+            value_setter_config,
             accounts::AccountConfig { pub_keys: vec![] },
         ),
         value_setter_admin_private_key,

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -9,7 +9,7 @@ use sov_modules_api::default_context::ZkDefaultContext;
 #[cfg(feature = "native")]
 use sov_modules_api::Address;
 use sov_modules_api::Context;
-#[cfg(test)]
+//#[cfg(test)]
 use sov_modules_api::{PublicKey, Spec};
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
@@ -21,7 +21,10 @@ use sovereign_sdk::stf::{StateTransitionRunner, ZkConfig};
 #[cfg(test)]
 use std::path::Path;
 
-#[cfg(test)]
+use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
+use sov_modules_api::Hasher;
+
+//#[cfg(test)]
 pub(crate) type C = DefaultContext;
 
 pub struct DemoAppRunner<C: Context>(pub DemoApp<C>);
@@ -102,6 +105,7 @@ pub fn create_demo_genesis_config<C: Context>(
     sequencer_address: C::Address,
     sequencer_da_address: Vec<u8>,
 ) -> GenesisConfig<C> {
+    /*
     let token_config: bank::TokenConfig<C> = bank::TokenConfig {
         token_name: "sov-test-token".to_owned(),
         address_and_balances: vec![(sequencer_address.clone(), 10_000)],
@@ -128,7 +132,9 @@ pub fn create_demo_genesis_config<C: Context>(
         (),
         (),
         accounts::AccountConfig { pub_keys: vec![] },
-    )
+    )*/
+
+    todo!()
 }
 
 #[cfg(test)]
@@ -146,11 +152,20 @@ pub(crate) fn create_sequencer_config(
     }
 }
 
+pub fn generate_address(key: &str) -> <C as Spec>::Address {
+    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    Address::from(hash)
+}
+
 #[cfg(test)]
-pub(crate) fn create_config(initial_sequencer_balance: u64) -> GenesisConfig<DefaultContext> {
-    type C = DefaultContext;
-    let pub_key = <C as Spec>::PublicKey::try_from(SEQ_PUB_KEY_STR).unwrap();
-    let seq_address = pub_key.to_address::<<C as Spec>::Address>();
+pub(crate) fn create_config(
+    initial_sequencer_balance: u64,
+) -> (
+    GenesisConfig<DefaultContext>,
+    DefaultPrivateKey,
+    DefaultPrivateKey,
+) {
+    let seq_address = generate_address(SEQ_PUB_KEY_STR);
 
     let token_config: bank::TokenConfig<DefaultContext> = bank::TokenConfig {
         token_name: TOKEN_NAME.to_owned(),
@@ -169,12 +184,24 @@ pub(crate) fn create_config(initial_sequencer_balance: u64) -> GenesisConfig<Def
 
     let sequencer_config = create_sequencer_config(seq_address, token_address);
 
-    GenesisConfig::new(
-        sequencer_config,
-        bank_config,
-        (),
-        (),
-        accounts::AccountConfig { pub_keys: vec![] },
+    let value_setter_admin_private_key = DefaultPrivateKey::generate();
+    let value_setter_admin_pub_key = value_setter_admin_private_key.pub_key();
+    let value_setter_admin_address: <C as Spec>::Address = value_setter_admin_pub_key.to_address();
+
+    let election_admin_private_key = DefaultPrivateKey::generate();
+    let election_admin_pub_key = election_admin_private_key.pub_key();
+    let election_admin_address: <C as Spec>::Address = election_admin_pub_key.to_address();
+
+    (
+        GenesisConfig::new(
+            sequencer_config,
+            bank_config,
+            election_admin_address,
+            value_setter_admin_address,
+            accounts::AccountConfig { pub_keys: vec![] },
+        ),
+        value_setter_admin_private_key,
+        election_admin_private_key,
     )
 }
 

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -36,7 +36,7 @@ pub type DemoApp<C> = AppTemplate<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTx
 pub const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
 pub const LOCKED_AMOUNT: u64 = 200;
 pub const SEQ_PUB_KEY_STR: &str = "seq_pub_key";
-pub const TOKEN_NAME: &str = "test-token";
+pub const TOKEN_NAME: &str = "sov-test-token";
 
 #[cfg(feature = "native")]
 impl StateTransitionRunner<ProverConfig> for DemoAppRunner<DefaultContext> {
@@ -85,7 +85,11 @@ impl StateTransitionRunner<ZkConfig> for DemoAppRunner<ZkDefaultContext> {
 }
 
 #[cfg(feature = "native")]
-pub fn create_config(
+/// Creates config for a rollup with some default settings, the config is used in demos and tests.
+///
+/// * `value_setter_admin_private_key` - Private key for the ValueSetter module admin.
+/// * `election_admin_private_key` - Private key for the Election module admin.
+pub fn create_demo_config(
     initial_sequencer_balance: u64,
     value_setter_admin_private_key: &DefaultPrivateKey,
     election_admin_private_key: &DefaultPrivateKey,

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -1,16 +1,14 @@
-use crate::runtime::GenesisConfig;
-use crate::runtime::Runtime;
+use crate::runtime::{GenesisConfig, Runtime};
 use crate::tx_hooks_impl::DemoAppTxHooks;
 use crate::tx_verifier_impl::DemoAppTxVerifier;
 use sov_app_template::AppTemplate;
+pub use sov_app_template::Batch;
 #[cfg(feature = "native")]
-use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::default_context::ZkDefaultContext;
+use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
+use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 #[cfg(feature = "native")]
-use sov_modules_api::Address;
 use sov_modules_api::Context;
-#[cfg(test)]
-use sov_modules_api::{PublicKey, Spec};
+use sov_modules_api::{Hasher, PublicKey, Spec};
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
 use sov_state::Storage;
@@ -21,14 +19,9 @@ use sovereign_sdk::stf::{StateTransitionRunner, ZkConfig};
 #[cfg(test)]
 use std::path::Path;
 
-use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::Hasher;
-
 #[cfg(test)]
 pub(crate) type C = DefaultContext;
-
 pub struct DemoAppRunner<C: Context>(pub DemoApp<C>);
-
 pub type ZkAppRunner = DemoAppRunner<ZkDefaultContext>;
 
 #[cfg(feature = "native")]
@@ -36,16 +29,10 @@ pub type NativeAppRunner = DemoAppRunner<DefaultContext>;
 
 pub type DemoApp<C> = AppTemplate<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>>;
 
-pub use sov_app_template::Batch;
-
-#[cfg(test)]
 pub const SEQUENCER_DA_ADDRESS: [u8; 32] = [1; 32];
-#[cfg(test)]
 pub const LOCKED_AMOUNT: u64 = 200;
-#[cfg(test)]
 pub const SEQ_PUB_KEY_STR: &str = "seq_pub_key";
-#[cfg(test)]
-pub const TOKEN_NAME: &str = "Token0";
+pub const TOKEN_NAME: &str = "test-token";
 
 #[cfg(feature = "native")]
 impl StateTransitionRunner<ProverConfig> for DemoAppRunner<DefaultContext> {
@@ -93,85 +80,33 @@ impl StateTransitionRunner<ZkConfig> for DemoAppRunner<ZkDefaultContext> {
     }
 }
 
-#[cfg(feature = "native")]
-pub fn create_mock_context_genesis_config(
-    sequencer_address: Address,
-    sequencer_da_address: Vec<u8>,
-) -> GenesisConfig<DefaultContext> {
-    create_demo_genesis_config::<DefaultContext>(sequencer_address, sequencer_da_address)
-}
-
-pub fn create_demo_genesis_config<C: Context>(
-    sequencer_address: C::Address,
-    sequencer_da_address: Vec<u8>,
-) -> GenesisConfig<C> {
-    /*
-    let token_config: bank::TokenConfig<C> = bank::TokenConfig {
-        token_name: "sov-test-token".to_owned(),
-        address_and_balances: vec![(sequencer_address.clone(), 10_000)],
-    };
-    let bank_config = bank::BankConfig {
-        tokens: vec![token_config],
-    };
-    let token_address = bank::create_token_address::<C>(
-        &bank_config.tokens[0].token_name,
-        &bank::genesis::DEPLOYER,
-        bank::genesis::SALT,
-    );
-    let sequencer_config = sequencer::SequencerConfig {
-        seq_rollup_address: sequencer_address,
-        seq_da_address: sequencer_da_address,
-        coins_to_lock: bank::Coins {
-            amount: 1000,
-            token_address,
-        },
-    };
-    GenesisConfig::new(
-        sequencer_config,
-        bank_config,
-        (),
-        (),
-        accounts::AccountConfig { pub_keys: vec![] },
-    )*/
-
-    todo!()
-}
-
-#[cfg(test)]
-pub(crate) fn create_sequencer_config(
-    seq_rollup_address: <DefaultContext as Spec>::Address,
-    token_address: <DefaultContext as Spec>::Address,
-) -> sequencer::SequencerConfig<DefaultContext> {
-    sequencer::SequencerConfig {
-        seq_rollup_address,
-        seq_da_address: SEQUENCER_DA_ADDRESS.to_vec(),
-        coins_to_lock: bank::Coins {
-            amount: LOCKED_AMOUNT,
-            token_address,
-        },
-    }
-}
-
-#[cfg(test)]
-pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
-    Address::from(hash)
-}
-
-#[cfg(test)]
-pub(crate) fn create_config(
+pub fn create_config(
     initial_sequencer_balance: u64,
     value_setter_admin_private_key: &DefaultPrivateKey,
     election_admin_private_key: &DefaultPrivateKey,
 ) -> GenesisConfig<DefaultContext> {
+    create_genesis_config::<DefaultContext>(
+        initial_sequencer_balance,
+        generate_address::<DefaultContext>(SEQ_PUB_KEY_STR),
+        SEQUENCER_DA_ADDRESS.to_vec(),
+        value_setter_admin_private_key,
+        election_admin_private_key,
+    )
+}
+
+fn create_genesis_config<C: Context>(
+    initial_sequencer_balance: u64,
+    sequencer_address: C::Address,
+    sequencer_da_address: Vec<u8>,
+    value_setter_admin_private_key: &DefaultPrivateKey,
+    election_admin_private_key: &DefaultPrivateKey,
+) -> GenesisConfig<C> {
     use election::ElectionConfig;
     use value_setter::ValueSetterConfig;
 
-    let seq_address = generate_address(SEQ_PUB_KEY_STR);
-
-    let token_config: bank::TokenConfig<DefaultContext> = bank::TokenConfig {
+    let token_config: bank::TokenConfig<C> = bank::TokenConfig {
         token_name: TOKEN_NAME.to_owned(),
-        address_and_balances: vec![(seq_address.clone(), initial_sequencer_balance)],
+        address_and_balances: vec![(sequencer_address.clone(), initial_sequencer_balance)],
     };
 
     let bank_config = bank::BankConfig {
@@ -184,7 +119,14 @@ pub(crate) fn create_config(
         bank::genesis::SALT,
     );
 
-    let sequencer_config = create_sequencer_config(seq_address, token_address);
+    let sequencer_config = sequencer::SequencerConfig {
+        seq_rollup_address: sequencer_address,
+        seq_da_address: sequencer_da_address.to_vec(),
+        coins_to_lock: bank::Coins {
+            amount: LOCKED_AMOUNT,
+            token_address,
+        },
+    };
 
     let value_setter_config = ValueSetterConfig {
         admin: value_setter_admin_private_key.pub_key().to_address(),
@@ -201,6 +143,11 @@ pub(crate) fn create_config(
         value_setter_config,
         accounts::AccountConfig { pub_keys: vec![] },
     )
+}
+
+pub fn generate_address<C: Context>(key: &str) -> <C as Spec>::Address {
+    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    <C as Spec>::Address::from(hash)
 }
 
 #[cfg(test)]

--- a/demo-app/src/app.rs
+++ b/demo-app/src/app.rs
@@ -9,7 +9,7 @@ use sov_modules_api::default_context::ZkDefaultContext;
 #[cfg(feature = "native")]
 use sov_modules_api::Address;
 use sov_modules_api::Context;
-//#[cfg(test)]
+#[cfg(test)]
 use sov_modules_api::{PublicKey, Spec};
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
@@ -24,7 +24,7 @@ use std::path::Path;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::Hasher;
 
-//#[cfg(test)]
+#[cfg(test)]
 pub(crate) type C = DefaultContext;
 
 pub struct DemoAppRunner<C: Context>(pub DemoApp<C>);
@@ -152,6 +152,7 @@ pub(crate) fn create_sequencer_config(
     }
 }
 
+#[cfg(test)]
 pub fn generate_address(key: &str) -> <C as Spec>::Address {
     let hash = <C as Spec>::Hasher::hash(key.as_bytes());
     Address::from(hash)

--- a/demo-app/src/data_generation/election_data.rs
+++ b/demo-app/src/data_generation/election_data.rs
@@ -1,9 +1,6 @@
-use std::rc::Rc;
-
-use sov_modules_api::Hasher;
-use sov_modules_api::{default_context::DefaultContext, Spec};
-
 use super::*;
+use sov_modules_api::default_context::DefaultContext;
+use std::rc::Rc;
 
 struct CallGenerator {
     election_admin_nonce: u64,

--- a/demo-app/src/data_generation/mod.rs
+++ b/demo-app/src/data_generation/mod.rs
@@ -1,14 +1,13 @@
-use std::rc::Rc;
-
 use crate::runtime::Runtime;
 use crate::tx_verifier_impl::Transaction;
-
 use borsh::BorshSerialize;
 use sov_app_template::RawTx;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::default_signature::{DefaultPublicKey, DefaultSignature};
-use sov_modules_api::PublicKey;
+use sov_modules_api::default_signature::DefaultSignature;
+use sov_modules_api::Hasher;
+use sov_modules_api::{PublicKey, Spec};
+use std::rc::Rc;
 
 mod election_data;
 mod value_setter_data;
@@ -27,30 +26,42 @@ pub fn simulate_da(
 
     messages
 }
-/*
-pub fn simulate_da_with_revert_msg() -> Vec<RawTx> {
-    let election = election_data::InvalidElectionCallMessages {};
+
+pub fn simulate_da_with_revert_msg(election_admin: DefaultPrivateKey) -> Vec<RawTx> {
+    let election = election_data::InvalidElectionCallMessages::new(election_admin);
     election.create_raw_txs()
 }
 
-pub fn simulate_da_with_bad_sig() -> Vec<RawTx> {
-    let election = election_data::BadSigElectionCallMessages {};
+pub fn simulate_da_with_bad_sig(election_admin: DefaultPrivateKey) -> Vec<RawTx> {
+    let election = election_data::BadSigElectionCallMessages::new(election_admin);
     election.create_raw_txs()
 }
 
 // TODO: Remove once we fix test with bad nonce
 //   https://github.com/Sovereign-Labs/sovereign/issues/235
 #[allow(unused)]
-pub fn simulate_da_with_bad_nonce() -> Vec<RawTx> {
-    let election = election_data::BadNonceElectionCallMessages {};
+pub fn simulate_da_with_bad_nonce(election_admin: DefaultPrivateKey) -> Vec<RawTx> {
+    let election = election_data::BadNonceElectionCallMessages::new(election_admin);
     election.create_raw_txs()
 }
 
-pub fn simulate_da_with_bad_serialization() -> Vec<RawTx> {
-    let election = election_data::BadSerializationElectionCallMessages {};
+pub fn simulate_da_with_bad_serialization(election_admin: DefaultPrivateKey) -> Vec<RawTx> {
+    let election = election_data::BadSerializationElectionCallMessages::new(election_admin);
     election.create_raw_txs()
 }
-*/
+
+pub(crate) fn sign_tx(
+    priv_key: &DefaultPrivateKey,
+    message: &[u8],
+    nonce: u64,
+) -> DefaultSignature {
+    let mut hasher = <DefaultContext as Spec>::Hasher::new();
+    hasher.update(message);
+    hasher.update(&nonce.to_le_bytes());
+    let msg_hash = hasher.finalize();
+    priv_key.sign(msg_hash)
+}
+
 trait MessageGenerator {
     type Call;
 

--- a/demo-app/src/data_generation/mod.rs
+++ b/demo-app/src/data_generation/mod.rs
@@ -17,23 +17,12 @@ pub fn simulate_da(
     value_setter_admin: DefaultPrivateKey,
     election_admin: DefaultPrivateKey,
 ) -> Vec<RawTx> {
-    let voters = vec![
-        Rc::new(DefaultPrivateKey::generate()),
-        Rc::new(DefaultPrivateKey::generate()),
-        Rc::new(DefaultPrivateKey::generate()),
-    ];
-
-    let election = election_data::ElectionCallMessages {
-        election_admin: Rc::new(election_admin),
-        voters,
-    };
+    let election = election_data::ElectionCallMessages::new(election_admin);
 
     let mut messages = Vec::default();
     messages.extend(election.create_raw_txs());
 
-    let value_setter = value_setter_data::ValueSetterMessages {
-        admin: Rc::new(value_setter_admin),
-    };
+    let value_setter = value_setter_data::ValueSetterMessages::new(value_setter_admin);
     messages.extend(value_setter.create_raw_txs());
 
     messages

--- a/demo-app/src/data_generation/value_setter_data.rs
+++ b/demo-app/src/data_generation/value_setter_data.rs
@@ -1,7 +1,6 @@
 use super::*;
-use sov_modules_api::Hasher;
 use sov_modules_api::{
-    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Spec,
+    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey,
 };
 
 pub struct ValueSetterMessages {
@@ -47,14 +46,7 @@ impl MessageGenerator for ValueSetterMessages {
         _is_last: bool,
     ) -> Transaction<DefaultContext> {
         let message = Runtime::<DefaultContext>::encode_value_setter_call(message);
-
-        let mut hasher = <DefaultContext as Spec>::Hasher::new();
-        hasher.update(&message);
-        hasher.update(&nonce.to_le_bytes());
-
-        let msg_hash = hasher.finalize();
-        let sig = sender.sign(msg_hash);
-
+        let sig = sign_tx(sender, &message, nonce);
         Transaction::<DefaultContext>::new(message, sender.pub_key(), sig, nonce)
     }
 }

--- a/demo-app/src/data_generation/value_setter_data.rs
+++ b/demo-app/src/data_generation/value_setter_data.rs
@@ -1,9 +1,12 @@
-use sov_modules_api::default_context::DefaultContext;
-
 use super::*;
+use sov_modules_api::Hasher;
+use sov_modules_api::{
+    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Spec,
+};
 
-fn value_setter_call_messages() -> Vec<(DefaultPublicKey, value_setter::call::CallMessage, u64)> {
-    let value_setter_admin = DefaultPublicKey::from("value_setter_admin");
+fn value_setter_call_messages(
+    admin: Rc<DefaultPrivateKey>,
+) -> Vec<(Rc<DefaultPrivateKey>, value_setter::call::CallMessage, u64)> {
     let mut value_setter_admin_nonce = 0;
     let mut messages = Vec::default();
 
@@ -14,43 +17,41 @@ fn value_setter_call_messages() -> Vec<(DefaultPublicKey, value_setter::call::Ca
     let new_value = 33;
     let set_value_msg_2 = value_setter::call::CallMessage::SetValue(new_value);
 
-    messages.push((
-        value_setter_admin.clone(),
-        set_value_msg_1,
-        value_setter_admin_nonce,
-    ));
+    messages.push((admin.clone(), set_value_msg_1, value_setter_admin_nonce));
 
     value_setter_admin_nonce += 1;
-    messages.push((
-        value_setter_admin,
-        set_value_msg_2,
-        value_setter_admin_nonce,
-    ));
+    messages.push((admin, set_value_msg_2, value_setter_admin_nonce));
 
     messages
 }
 
-pub struct ValueSetterMessages {}
+pub struct ValueSetterMessages {
+    pub(crate) admin: Rc<DefaultPrivateKey>,
+}
 
 impl MessageGenerator for ValueSetterMessages {
     type Call = value_setter::call::CallMessage;
 
-    fn create_messages(&self) -> Vec<(DefaultPublicKey, Self::Call, u64)> {
-        value_setter_call_messages()
+    fn create_messages(&self) -> Vec<(Rc<DefaultPrivateKey>, Self::Call, u64)> {
+        value_setter_call_messages(self.admin.clone())
     }
 
     fn create_tx(
         &self,
-        sender: DefaultPublicKey,
+        sender: &DefaultPrivateKey,
         message: Self::Call,
         nonce: u64,
         _is_last: bool,
     ) -> Transaction<DefaultContext> {
-        Transaction::<DefaultContext>::new(
-            Runtime::<DefaultContext>::encode_value_setter_call(message),
-            sender,
-            DefaultSignature::default(),
-            nonce,
-        )
+        let message = Runtime::<DefaultContext>::encode_value_setter_call(message);
+
+        let mut hasher = <DefaultContext as Spec>::Hasher::new();
+        hasher.update(&message);
+        hasher.update(&nonce.to_le_bytes());
+
+        let msg_hash = hasher.finalize();
+        let sig = sender.sign(msg_hash);
+
+        Transaction::<DefaultContext>::new(message, sender.pub_key(), sig, nonce)
     }
 }

--- a/demo-app/src/data_generation/value_setter_data.rs
+++ b/demo-app/src/data_generation/value_setter_data.rs
@@ -5,7 +5,15 @@ use sov_modules_api::{
 };
 
 pub struct ValueSetterMessages {
-    pub(crate) admin: Rc<DefaultPrivateKey>,
+    admin: Rc<DefaultPrivateKey>,
+}
+
+impl ValueSetterMessages {
+    pub fn new(admin: DefaultPrivateKey) -> Self {
+        Self {
+            admin: Rc::new(admin),
+        }
+    }
 }
 
 impl MessageGenerator for ValueSetterMessages {

--- a/demo-app/src/data_generation/value_setter_data.rs
+++ b/demo-app/src/data_generation/value_setter_data.rs
@@ -4,27 +4,6 @@ use sov_modules_api::{
     default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Spec,
 };
 
-fn value_setter_call_messages(
-    admin: Rc<DefaultPrivateKey>,
-) -> Vec<(Rc<DefaultPrivateKey>, value_setter::call::CallMessage, u64)> {
-    let mut value_setter_admin_nonce = 0;
-    let mut messages = Vec::default();
-
-    let new_value = 99;
-
-    let set_value_msg_1 = value_setter::call::CallMessage::SetValue(new_value);
-
-    let new_value = 33;
-    let set_value_msg_2 = value_setter::call::CallMessage::SetValue(new_value);
-
-    messages.push((admin.clone(), set_value_msg_1, value_setter_admin_nonce));
-
-    value_setter_admin_nonce += 1;
-    messages.push((admin, set_value_msg_2, value_setter_admin_nonce));
-
-    messages
-}
-
 pub struct ValueSetterMessages {
     pub(crate) admin: Rc<DefaultPrivateKey>,
 }
@@ -33,7 +12,23 @@ impl MessageGenerator for ValueSetterMessages {
     type Call = value_setter::call::CallMessage;
 
     fn create_messages(&self) -> Vec<(Rc<DefaultPrivateKey>, Self::Call, u64)> {
-        value_setter_call_messages(self.admin.clone())
+        let admin = self.admin.clone();
+        let mut value_setter_admin_nonce = 0;
+        let mut messages = Vec::default();
+
+        let new_value = 99;
+
+        let set_value_msg_1 = value_setter::call::CallMessage::SetValue(new_value);
+
+        let new_value = 33;
+        let set_value_msg_2 = value_setter::call::CallMessage::SetValue(new_value);
+
+        messages.push((admin.clone(), set_value_msg_1, value_setter_admin_nonce));
+
+        value_setter_admin_nonce += 1;
+        messages.push((admin, set_value_msg_2, value_setter_admin_nonce));
+
+        messages
     }
 
     fn create_tx(

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -45,13 +45,14 @@ pub mod test {
     #[test]
     fn test_demo_values_in_db() {
         let path = schemadb::temppath::TempPath::new();
+        let (config, value_setter_admin, election_admin) = create_config(LOCKED_AMOUNT + 1);
         {
             let mut demo = create_new_demo(&path);
 
-            demo.init_chain(create_config(LOCKED_AMOUNT + 1));
+            demo.init_chain(config);
             demo.begin_slot(Default::default());
 
-            let txs = simulate_da();
+            let txs = simulate_da(value_setter_admin, election_admin);
 
             let apply_blob_outcome = demo
                 .apply_blob(TestBlob::new(Batch { txs }, &SEQUENCER_DA_ADDRESS), None)
@@ -91,7 +92,7 @@ pub mod test {
             assert_eq!(resp, value_setter::query::Response { value: Some(33) });
         }
     }
-
+    /*
     #[test]
     fn test_demo_values_in_cache() {
         let path = schemadb::temppath::TempPath::new();
@@ -197,5 +198,5 @@ pub mod test {
             matches!(apply_blob_result, SequencerOutcome::Ignored),
             "Batch should have been skipped due to insufficient funds"
         );
-    }
+    }*/
 }

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -9,7 +9,7 @@ pub mod test {
     use sovereign_sdk::{da::BlobTransactionTrait, serial::Encode, stf::StateTransitionFunction};
 
     use crate::{
-        app::{create_config, create_new_demo, C, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
+        app::{create_demo_config, create_new_demo, C, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
         data_generation::{simulate_da, QueryGenerator},
         helpers::query_and_deserialize,
         runtime::Runtime,
@@ -50,7 +50,7 @@ pub mod test {
         let value_setter_admin_private_key = DefaultPrivateKey::generate();
         let election_admin_private_key = DefaultPrivateKey::generate();
 
-        let config = create_config(
+        let config = create_demo_config(
             LOCKED_AMOUNT + 1,
             &value_setter_admin_private_key,
             &election_admin_private_key,
@@ -110,7 +110,7 @@ pub mod test {
         let value_setter_admin_private_key = DefaultPrivateKey::generate();
         let election_admin_private_key = DefaultPrivateKey::generate();
 
-        let config = create_config(
+        let config = create_demo_config(
             LOCKED_AMOUNT + 1,
             &value_setter_admin_private_key,
             &election_admin_private_key,
@@ -161,7 +161,7 @@ pub mod test {
         let value_setter_admin_private_key = DefaultPrivateKey::generate();
         let election_admin_private_key = DefaultPrivateKey::generate();
 
-        let config = create_config(
+        let config = create_demo_config(
             LOCKED_AMOUNT + 1,
             &value_setter_admin_private_key,
             &election_admin_private_key,
@@ -215,7 +215,7 @@ pub mod test {
         let value_setter_admin_private_key = DefaultPrivateKey::generate();
         let election_admin_private_key = DefaultPrivateKey::generate();
 
-        let config = create_config(
+        let config = create_demo_config(
             LOCKED_AMOUNT - 1,
             &value_setter_admin_private_key,
             &election_admin_private_key,

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -2,7 +2,9 @@
 pub mod test {
     use borsh::{BorshDeserialize, BorshSerialize};
     use sov_app_template::{Batch, SequencerOutcome};
-    use sov_modules_api::{default_context::DefaultContext, Address};
+    use sov_modules_api::{
+        default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Address,
+    };
     use sov_state::ProverStorage;
     use sovereign_sdk::{da::BlobTransactionTrait, serial::Encode, stf::StateTransitionFunction};
 
@@ -45,14 +47,21 @@ pub mod test {
     #[test]
     fn test_demo_values_in_db() {
         let path = schemadb::temppath::TempPath::new();
-        let (config, value_setter_admin, election_admin) = create_config(LOCKED_AMOUNT + 1);
+        let value_setter_admin_private_key = DefaultPrivateKey::generate();
+        let election_admin_private_key = DefaultPrivateKey::generate();
+
+        let config = create_config(
+            LOCKED_AMOUNT + 1,
+            &value_setter_admin_private_key,
+            &election_admin_private_key,
+        );
         {
             let mut demo = create_new_demo(&path);
 
             demo.init_chain(config);
             demo.begin_slot(Default::default());
 
-            let txs = simulate_da(value_setter_admin, election_admin);
+            let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
             let apply_blob_outcome = demo
                 .apply_blob(TestBlob::new(Batch { txs }, &SEQUENCER_DA_ADDRESS), None)

--- a/demo-app/src/tests.rs
+++ b/demo-app/src/tests.rs
@@ -101,16 +101,25 @@ pub mod test {
             assert_eq!(resp, value_setter::query::Response { value: Some(33) });
         }
     }
-    /*
+
     #[test]
     fn test_demo_values_in_cache() {
         let path = schemadb::temppath::TempPath::new();
         let mut demo = create_new_demo(&path);
 
-        demo.init_chain(create_config(LOCKED_AMOUNT + 1));
+        let value_setter_admin_private_key = DefaultPrivateKey::generate();
+        let election_admin_private_key = DefaultPrivateKey::generate();
+
+        let config = create_config(
+            LOCKED_AMOUNT + 1,
+            &value_setter_admin_private_key,
+            &election_admin_private_key,
+        );
+
+        demo.init_chain(config);
         demo.begin_slot(Default::default());
 
-        let txs = simulate_da();
+        let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
         let apply_blob_outcome = demo
             .apply_blob(TestBlob::new(Batch { txs }, &SEQUENCER_DA_ADDRESS), None)
@@ -148,13 +157,22 @@ pub mod test {
     #[test]
     fn test_demo_values_not_in_db() {
         let path = schemadb::temppath::TempPath::new();
+
+        let value_setter_admin_private_key = DefaultPrivateKey::generate();
+        let election_admin_private_key = DefaultPrivateKey::generate();
+
+        let config = create_config(
+            LOCKED_AMOUNT + 1,
+            &value_setter_admin_private_key,
+            &election_admin_private_key,
+        );
         {
             let mut demo = create_new_demo(&path);
 
-            demo.init_chain(create_config(LOCKED_AMOUNT + 1));
+            demo.init_chain(config);
             demo.begin_slot(Default::default());
 
-            let txs = simulate_da();
+            let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
             let apply_blob_outcome = demo
                 .apply_blob(TestBlob::new(Batch { txs }, &SEQUENCER_DA_ADDRESS), None)
@@ -193,12 +211,22 @@ pub mod test {
     #[test]
     fn test_sequencer_insufficient_funds() {
         let path = schemadb::temppath::TempPath::new();
+
+        let value_setter_admin_private_key = DefaultPrivateKey::generate();
+        let election_admin_private_key = DefaultPrivateKey::generate();
+
+        let config = create_config(
+            LOCKED_AMOUNT - 1,
+            &value_setter_admin_private_key,
+            &election_admin_private_key,
+        );
+
         let mut demo = create_new_demo(&path);
 
-        demo.init_chain(create_config(LOCKED_AMOUNT - 1));
+        demo.init_chain(config);
         demo.begin_slot(Default::default());
 
-        let txs = simulate_da();
+        let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
         let apply_blob_result = demo
             .apply_blob(TestBlob::new(Batch { txs }, &SEQUENCER_DA_ADDRESS), None)
@@ -207,5 +235,5 @@ pub mod test {
             matches!(apply_blob_result, SequencerOutcome::Ignored),
             "Batch should have been skipped due to insufficient funds"
         );
-    }*/
+    }
 }

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,4 +1,4 @@
-use core::panic;
+/*use core::panic;
 
 use crate::{
     app::{create_config, create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
@@ -221,3 +221,4 @@ fn test_tx_bad_serialization() {
         assert_eq!(resp.data.unwrap().balance, SEQUENCER_BALANCE_DELTA);
     }
 }
+*/

--- a/demo-app/src/tx_revert_tests.rs
+++ b/demo-app/src/tx_revert_tests.rs
@@ -1,7 +1,7 @@
 use core::panic;
 
 use crate::{
-    app::{create_config, create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
+    app::{create_demo_config, create_new_demo, LOCKED_AMOUNT, SEQUENCER_DA_ADDRESS},
     data_generation::{
         simulate_da_with_bad_serialization, simulate_da_with_bad_sig, simulate_da_with_revert_msg,
         QueryGenerator,
@@ -26,7 +26,7 @@ fn test_tx_revert() {
     let value_setter_admin_private_key = DefaultPrivateKey::generate();
     let election_admin_private_key = DefaultPrivateKey::generate();
 
-    let config = create_config(
+    let config = create_demo_config(
         SEQUENCER_BALANCE,
         &value_setter_admin_private_key,
         &election_admin_private_key,
@@ -96,7 +96,7 @@ fn test_tx_bad_sig() {
     let value_setter_admin_private_key = DefaultPrivateKey::generate();
     let election_admin_private_key = DefaultPrivateKey::generate();
 
-    let config = create_config(
+    let config = create_demo_config(
         SEQUENCER_BALANCE,
         &value_setter_admin_private_key,
         &election_admin_private_key,
@@ -201,7 +201,7 @@ fn test_tx_bad_serialization() {
     let value_setter_admin_private_key = DefaultPrivateKey::generate();
     let election_admin_private_key = DefaultPrivateKey::generate();
 
-    let config = create_config(
+    let config = create_demo_config(
         SEQUENCER_BALANCE,
         &value_setter_admin_private_key,
         &election_admin_private_key,

--- a/demo-app/src/tx_verifier_impl.rs
+++ b/demo-app/src/tx_verifier_impl.rs
@@ -49,6 +49,7 @@ impl<C: Context> TxVerifier for DemoAppTxVerifier<C> {
         let mut hasher = C::Hasher::new();
         hasher.update(&tx.runtime_msg);
         hasher.update(&tx.nonce.to_le_bytes());
+
         let msg_hash = hasher.finalize();
 
         tx.signature.verify(&tx.pub_key, msg_hash)?;

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -118,6 +118,8 @@ where
         let sequencer = blob.sender();
         let sequencer = sequencer.as_ref();
 
+        println!("1");
+
         if let Err(e) = self
             .tx_hooks
             .enter_apply_blob(sequencer, &mut batch_workspace)
@@ -134,6 +136,8 @@ where
                 inner: SequencerOutcome::Ignored,
             };
         }
+
+        println!("2");
 
         // Commit `enter_apply_batch` changes.
         batch_workspace = batch_workspace.commit().to_revertable();
@@ -152,6 +156,7 @@ where
             }
         };
 
+        println!("3");
         // Run the stateless verification, since it is stateless we don't commit.
         let txs = match self
             .tx_verifier
@@ -159,6 +164,7 @@ where
         {
             Ok(txs) => txs,
             Err(e) => {
+                println!("Error {:?}", e);
                 // Revert on error
                 let batch_workspace = batch_workspace.revert();
                 self.working_set = Some(batch_workspace.revert());
@@ -170,6 +176,8 @@ where
                 };
             }
         };
+
+        println!("4");
 
         let mut tx_receipts = Vec::with_capacity(txs.len());
 

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -159,7 +159,6 @@ where
         {
             Ok(txs) => txs,
             Err(e) => {
-                println!("Error {:?}", e);
                 // Revert on error
                 let batch_workspace = batch_workspace.revert();
                 self.working_set = Some(batch_workspace.revert());

--- a/sov-modules/sov-app-template/src/lib.rs
+++ b/sov-modules/sov-app-template/src/lib.rs
@@ -118,8 +118,6 @@ where
         let sequencer = blob.sender();
         let sequencer = sequencer.as_ref();
 
-        println!("1");
-
         if let Err(e) = self
             .tx_hooks
             .enter_apply_blob(sequencer, &mut batch_workspace)
@@ -136,8 +134,6 @@ where
                 inner: SequencerOutcome::Ignored,
             };
         }
-
-        println!("2");
 
         // Commit `enter_apply_batch` changes.
         batch_workspace = batch_workspace.commit().to_revertable();
@@ -156,7 +152,6 @@ where
             }
         };
 
-        println!("3");
         // Run the stateless verification, since it is stateless we don't commit.
         let txs = match self
             .tx_verifier
@@ -176,8 +171,6 @@ where
                 };
             }
         };
-
-        println!("4");
 
         let mut tx_receipts = Vec::with_capacity(txs.len());
 

--- a/sov-modules/sov-modules-api/Cargo.toml
+++ b/sov-modules/sov-modules-api/Cargo.toml
@@ -16,6 +16,9 @@ sha2 = { workspace = true }
 bech32 = { workspace = true }
 derive_more = { workspace = true }
 
+ed25519-dalek = { version = "1.0.1" }
+rand = "0.7"
+
 [features]
 default = ["native"]
 native = ["sov-state/native"]

--- a/sov-modules/sov-modules-api/Cargo.toml
+++ b/sov-modules/sov-modules-api/Cargo.toml
@@ -17,9 +17,9 @@ bech32 = { workspace = true }
 derive_more = { workspace = true }
 
 ed25519-dalek = { version = "1.0.1" }
-rand = "0.7"
+rand = {version = "0.7", optional = true}
 
 [features]
 default = ["native"]
-native = ["sov-state/native"]
+native = ["sov-state/native", "rand"]
 

--- a/sov-modules/sov-modules-api/src/default_context.rs
+++ b/sov-modules/sov-modules-api/src/default_context.rs
@@ -2,11 +2,9 @@ use crate::default_signature::{DefaultPublicKey, DefaultSignature};
 use crate::{Address, AddressTrait, Context, PublicKey, Spec};
 
 use jmt::SimpleHasher;
-
 #[cfg(feature = "native")]
 use serde::{Deserialize, Serialize};
 use sov_state::DefaultStorageSpec;
-
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
 use sov_state::ZkStorage;

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -73,7 +73,7 @@ impl BorshDeserialize for DefaultSignature {
         reader.read_exact(&mut buffer)?;
 
         Ok(Self {
-            msg_sig: DalekSignature::from_bytes(&buffer).unwrap(),
+            msg_sig: DalekSignature::from_bytes(&buffer)?,
         })
     }
 }

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -51,7 +51,7 @@ impl BorshDeserialize for DefaultPublicKey {
         reader.read_exact(&mut buffer)?;
 
         Ok(Self {
-            pub_key: DalekPublicKey::from_bytes(&buffer).unwrap(),
+            msg_sig: DalekSignature::from_bytes(&buffer)?,
         })
     }
 }

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -1,7 +1,9 @@
 use crate::{SigVerificationError, Signature};
 use borsh::{BorshDeserialize, BorshSerialize};
-use ed25519_dalek::ed25519::signature::Signature as DalekSignatureTrait;
-use ed25519_dalek::{PublicKey as DalekPublicKey, Signature as DalekSignature, Verifier};
+use ed25519_dalek::{
+    ed25519::signature::Signature as DalekSignatureTrait, PublicKey as DalekPublicKey,
+    Signature as DalekSignature, Verifier,
+};
 
 use ed25519_dalek::{PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
 
@@ -9,8 +11,6 @@ use ed25519_dalek::{PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
 pub mod private_key {
     use super::{DefaultPublicKey, DefaultSignature};
     use ed25519_dalek::{Keypair, Signer};
-
-    // TODO feature gate it in Cargo.toml
     use rand::rngs::OsRng;
 
     pub struct DefaultPrivateKey {

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -97,6 +97,6 @@ impl Signature for DefaultSignature {
         pub_key
             .pub_key
             .verify_strict(&msg_hash, &self.msg_sig)
-            .map_err(|_| SigVerificationError::BadSignature)
+            .map_err(|e| SigVerificationError::BadSignature(e.to_string()))
     }
 }

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -48,7 +48,7 @@ pub struct DefaultPublicKey {
 impl BorshDeserialize for DefaultPublicKey {
     fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut buffer = [0; PUBLIC_KEY_LENGTH];
-        reader.read_exact(&mut buffer).unwrap();
+        reader.read_exact(&mut buffer)?;
 
         Ok(Self {
             pub_key: DalekPublicKey::from_bytes(&buffer).unwrap(),

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -50,9 +50,10 @@ impl BorshDeserialize for DefaultPublicKey {
         let mut buffer = [0; PUBLIC_KEY_LENGTH];
         reader.read_exact(&mut buffer)?;
 
-        Ok(Self {
-            msg_sig: DalekSignature::from_bytes(&buffer)?,
-        })
+        let pub_key = DalekPublicKey::from_bytes(&buffer)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        Ok(Self { pub_key })
     }
 }
 
@@ -72,9 +73,10 @@ impl BorshDeserialize for DefaultSignature {
         let mut buffer = [0; SIGNATURE_LENGTH];
         reader.read_exact(&mut buffer)?;
 
-        Ok(Self {
-            msg_sig: DalekSignature::from_bytes(&buffer)?,
-        })
+        let msg_sig = DalekSignature::from_bytes(&buffer)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        Ok(Self { msg_sig })
     }
 }
 

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -2,7 +2,7 @@ use crate::{SigVerificationError, Signature};
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{
     ed25519::signature::Signature as DalekSignatureTrait, PublicKey as DalekPublicKey,
-    Signature as DalekSignature, Verifier,
+    Signature as DalekSignature,
 };
 
 use ed25519_dalek::{PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
@@ -94,7 +94,7 @@ impl Signature for DefaultSignature {
     ) -> Result<(), SigVerificationError> {
         pub_key
             .pub_key
-            .verify(&msg_hash, &self.msg_sig)
+            .verify_strict(&msg_hash, &self.msg_sig)
             .map_err(|_| SigVerificationError::BadSignature)
     }
 }

--- a/sov-modules/sov-modules-api/src/default_signature.rs
+++ b/sov-modules/sov-modules-api/src/default_signature.rs
@@ -70,7 +70,7 @@ pub struct DefaultSignature {
 impl BorshDeserialize for DefaultSignature {
     fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut buffer = [0; SIGNATURE_LENGTH];
-        reader.read_exact(&mut buffer).unwrap();
+        reader.read_exact(&mut buffer)?;
 
         Ok(Self {
             msg_sig: DalekSignature::from_bytes(&buffer).unwrap(),

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -107,13 +107,7 @@ pub trait Spec {
 
     type Storage: Storage + Clone;
 
-    type PublicKey: borsh::BorshDeserialize
-        + borsh::BorshSerialize
-        + Eq
-        + TryFrom<&'static str>
-        + Clone
-        + Debug
-        + PublicKey;
+    type PublicKey: borsh::BorshDeserialize + borsh::BorshSerialize + Eq + Clone + Debug + PublicKey;
 
     type Hasher: Hasher;
 

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -9,8 +9,9 @@ mod encode;
 mod error;
 mod prefix;
 mod response;
-mod tests;
 
+#[cfg(test)]
+mod tests;
 pub use crate::bech32::AddressBech32;
 pub use dispatch::{DispatchCall, DispatchQuery, Genesis};
 pub use error::Error;

--- a/sov-modules/sov-modules-api/src/lib.rs
+++ b/sov-modules/sov-modules-api/src/lib.rs
@@ -70,8 +70,8 @@ impl Display for Address {
 
 #[derive(Error, Debug)]
 pub enum SigVerificationError {
-    #[error("Bad signature")]
-    BadSignature,
+    #[error("Bad signature {0}")]
+    BadSignature(String),
 }
 
 /// Signature used in the module system.

--- a/sov-modules/sov-modules-api/src/tests.rs
+++ b/sov-modules/sov-modules-api/src/tests.rs
@@ -1,3 +1,9 @@
+use crate::{
+    default_signature::{private_key::DefaultPrivateKey, DefaultPublicKey, DefaultSignature},
+    Signature,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+
 #[test]
 fn test_account_bech32_display() {
     let expected_addr: Vec<u8> = (1..=32).collect();
@@ -6,4 +12,27 @@ fn test_account_bech32_display() {
         account.to_string(),
         "sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusq4vrkje"
     );
+}
+
+#[test]
+fn test_pub_key_serialization() {
+    let pub_key = DefaultPrivateKey::generate().pub_key();
+    let serialized_pub_key = pub_key.try_to_vec().unwrap();
+
+    let deserialized_pub_key = DefaultPublicKey::try_from_slice(&serialized_pub_key).unwrap();
+    assert_eq!(pub_key, deserialized_pub_key)
+}
+
+#[test]
+fn test_signature_serialization() {
+    let msg = [1; 32];
+    let priv_key = DefaultPrivateKey::generate();
+
+    let sig = priv_key.sign(msg);
+    let serialized_sig = sig.try_to_vec().unwrap();
+    let deserialized_sig = DefaultSignature::try_from_slice(&serialized_sig).unwrap();
+    assert_eq!(sig, deserialized_sig);
+
+    let pub_key = priv_key.pub_key();
+    deserialized_sig.verify(&pub_key, msg).unwrap()
 }

--- a/sov-modules/sov-modules-impl/accounts/Cargo.toml
+++ b/sov-modules/sov-modules-impl/accounts/Cargo.toml
@@ -8,7 +8,6 @@ resolver = "2"
 sov-modules-api = { path = "../../sov-modules-api"}
 sov-state = { path = "../../sov-state", features = ["temp"] }
 
-
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }

--- a/sov-modules/sov-modules-impl/accounts/Cargo.toml
+++ b/sov-modules/sov-modules-impl/accounts/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 sov-modules-api = { path = "../../sov-modules-api"}
 sov-state = { path = "../../sov-state", features = ["temp"] }
 
+
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }

--- a/sov-modules/sov-modules-impl/accounts/src/tests.rs
+++ b/sov-modules/sov-modules-impl/accounts/src/tests.rs
@@ -4,8 +4,8 @@ use crate::{
     AccountConfig, Accounts,
 };
 use sov_modules_api::{
-    default_context::DefaultContext, default_signature::DefaultPublicKey, AddressBech32, Context,
-    Module, ModuleInfo, PublicKey, Spec,
+    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey,
+    AddressBech32, Context, Module, ModuleInfo, PublicKey, Spec,
 };
 use sov_state::{ProverStorage, WorkingSet};
 
@@ -13,7 +13,9 @@ type C = DefaultContext;
 
 #[test]
 fn test_config_account() {
-    let init_pub_key = DefaultPublicKey::from("init_pub_key");
+    let priv_key = DefaultPrivateKey::generate();
+
+    let init_pub_key = priv_key.pub_key();
     let init_pub_key_addr = init_pub_key.to_address::<<C as Spec>::Address>();
 
     let account_config = AccountConfig::<C> {
@@ -52,7 +54,9 @@ fn test_update_account() {
     let accounts = &mut Accounts::<C>::new();
     let hooks = hooks::Hooks::<C>::new();
 
-    let sender = DefaultPublicKey::from("pub_key");
+    let priv_key = DefaultPrivateKey::generate();
+
+    let sender = priv_key.pub_key();
     let sender_addr = sender.to_address::<<C as Spec>::Address>();
     let sender_context = C::new(sender_addr.clone());
 
@@ -80,8 +84,9 @@ fn test_update_account() {
 
     // Test public key update
     {
-        let new_pub_key = DefaultPublicKey::from("new_pub_key");
-        let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
+        let priv_key = DefaultPrivateKey::generate();
+        let new_pub_key = priv_key.pub_key();
+        let sig = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
         accounts
             .call(
                 call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
@@ -124,14 +129,15 @@ fn test_update_account_fails() {
     let accounts = &mut Accounts::<C>::new();
     let hooks = hooks::Hooks::<C>::new();
 
-    let sender_1 = DefaultPublicKey::from("pub_key_1");
+    let sender_1 = DefaultPrivateKey::generate().pub_key();
     let sender_context_1 = C::new(sender_1.to_address());
     hooks
         .get_or_create_default_account(sender_1, native_working_set)
         .unwrap();
 
-    let sender_2 = DefaultPublicKey::from("pub_key_2");
-    let sig_2 = sender_2.sign(call::UPDATE_ACCOUNT_MSG);
+    let priv_key = DefaultPrivateKey::generate();
+    let sender_2 = priv_key.pub_key();
+    let sig_2 = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
 
     hooks
         .get_or_create_default_account(sender_2.clone(), native_working_set)
@@ -153,7 +159,7 @@ fn test_get_acc_after_pub_key_update() {
     let accounts = &mut Accounts::<C>::new();
     let hooks = hooks::Hooks::<C>::new();
 
-    let sender_1 = DefaultPublicKey::from("pub_key_1");
+    let sender_1 = DefaultPrivateKey::generate().pub_key();
     let sender_1_addr = sender_1.to_address::<<C as Spec>::Address>();
     let sender_context_1 = C::new(sender_1_addr.clone());
 
@@ -161,8 +167,9 @@ fn test_get_acc_after_pub_key_update() {
         .get_or_create_default_account(sender_1, native_working_set)
         .unwrap();
 
-    let new_pub_key = DefaultPublicKey::from("pub_key_2");
-    let sig = new_pub_key.sign(call::UPDATE_ACCOUNT_MSG);
+    let priv_key = DefaultPrivateKey::generate();
+    let new_pub_key = priv_key.pub_key();
+    let sig = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
     accounts
         .call(
             call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),

--- a/sov-modules/sov-modules-impl/bank/tests/helpers/mod.rs
+++ b/sov-modules/sov-modules-impl/bank/tests/helpers/mod.rs
@@ -3,7 +3,8 @@ use serde::de::DeserializeOwned;
 use bank::query::QueryMessage;
 use bank::{Bank, BankConfig, TokenConfig};
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Module, PublicKey, Spec};
+use sov_modules_api::Hasher;
+use sov_modules_api::{Address, Module, Spec};
 use sov_state::DefaultStorageSpec;
 use sov_state::{ProverStorage, WorkingSet};
 
@@ -20,8 +21,8 @@ pub fn query_and_deserialize<R: DeserializeOwned>(
 }
 
 pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let pk = <C as Spec>::PublicKey::try_from(key).unwrap();
-    pk.to_address::<<C as Spec>::Address>()
+    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    Address::from(hash)
 }
 
 pub fn create_bank_config_with_token(

--- a/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
@@ -5,10 +5,10 @@ use sov_state::WorkingSet;
 impl<C: sov_modules_api::Context> Election<C> {
     pub(crate) fn init_module(
         &self,
-        admin: &<Self as sov_modules_api::Module>::Config,
+        config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(admin.clone(), working_set);
+        self.admin.set(config.admin.clone(), working_set);
         self.is_frozen.set(false, working_set);
 
         Ok(())

--- a/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/genesis.rs
@@ -1,14 +1,14 @@
 use super::Election;
-use anyhow::{anyhow, Result};
-use sov_modules_api::PublicKey;
+use anyhow::Result;
 use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> Election<C> {
-    pub(crate) fn init_module(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
-        let admin_pub_key = C::PublicKey::try_from("election_admin")
-            .map_err(|_| anyhow!("Admin initialization failed"))?;
-
-        self.admin.set(admin_pub_key.to_address(), working_set);
+    pub(crate) fn init_module(
+        &self,
+        admin: &<Self as sov_modules_api::Module>::Config,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<()> {
+        self.admin.set(admin.clone(), working_set);
         self.is_frozen.set(false, working_set);
 
         Ok(())

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Election<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
     type Context = C;
 
-    type Config = ();
+    type Config = C::Address;
 
     type CallMessage = call::CallMessage<C>;
 
@@ -54,10 +54,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
 
     fn genesis(
         &self,
-        _config: &Self::Config,
+        config: &Self::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(), Error> {
-        Ok(self.init_module(working_set)?)
+        Ok(self.init_module(config, working_set)?)
     }
 
     fn call(

--- a/sov-modules/sov-modules-impl/examples/election/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/lib.rs
@@ -14,6 +14,10 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use types::Voter;
 
+pub struct ElectionConfig<C: sov_modules_api::Context> {
+    pub admin: C::Address,
+}
+
 #[derive(ModuleInfo, Clone)]
 pub struct Election<C: sov_modules_api::Context> {
     #[address]
@@ -46,7 +50,7 @@ pub struct Election<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Election<C> {
     type Context = C;
 
-    type Config = C::Address;
+    type Config = ElectionConfig<C>;
 
     type CallMessage = call::CallMessage<C>;
 

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -4,38 +4,37 @@ use super::{
     types::Candidate,
     Election,
 };
+use sov_modules_api::Address;
 
-use anyhow::anyhow;
 use sov_modules_api::{
     default_context::{DefaultContext, ZkDefaultContext},
-    default_signature::DefaultPublicKey,
+    default_signature::{private_key::DefaultPrivateKey, DefaultPublicKey},
     Context, Module, ModuleInfo, PublicKey,
 };
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 
 #[test]
 fn test_election() {
+    let admin = Address::from([1; 32]);
+
     let native_storage = ProverStorage::temporary();
     let mut native_working_set = WorkingSet::new(native_storage);
-    test_module::<DefaultContext>(&mut native_working_set);
+
+    test_module::<DefaultContext>(admin.clone(), &mut native_working_set);
 
     let (_log, witness) = native_working_set.freeze();
     let zk_storage = ZkStorage::new([0u8; 32]);
     let mut zk_working_set = WorkingSet::with_witness(zk_storage, witness);
-    test_module::<ZkDefaultContext>(&mut zk_working_set);
+    test_module::<ZkDefaultContext>(admin, &mut zk_working_set);
 }
 
-fn test_module<C: Context<PublicKey = DefaultPublicKey>>(working_set: &mut WorkingSet<C::Storage>) {
-    let admin_pub_key = C::PublicKey::try_from("election_admin")
-        .map_err(|_| anyhow!("Admin initialization failed"))
-        .unwrap();
-
-    let admin_context = C::new(admin_pub_key.to_address());
+fn test_module<C: Context>(admin: C::Address, working_set: &mut WorkingSet<C::Storage>) {
+    let admin_context = C::new(admin.clone());
     let election = &mut Election::<C>::new();
 
     // Init module
     {
-        election.genesis(&(), working_set).unwrap();
+        election.genesis(&admin, working_set).unwrap();
     }
 
     // Send candidates
@@ -49,9 +48,17 @@ fn test_module<C: Context<PublicKey = DefaultPublicKey>>(working_set: &mut Worki
             .unwrap();
     }
 
-    let voter_1 = DefaultPublicKey::from("voter_1").to_address::<C::Address>();
-    let voter_2 = DefaultPublicKey::from("voter_2").to_address::<C::Address>();
-    let voter_3 = DefaultPublicKey::from("voter_3").to_address::<C::Address>();
+    let voter_1 = DefaultPrivateKey::generate()
+        .pub_key()
+        .to_address::<C::Address>();
+
+    let voter_2 = DefaultPrivateKey::generate()
+        .pub_key()
+        .to_address::<C::Address>();
+
+    let voter_3 = DefaultPrivateKey::generate()
+        .pub_key()
+        .to_address::<C::Address>();
 
     // Register voters
     {

--- a/sov-modules/sov-modules-impl/examples/election/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/election/src/tests.rs
@@ -1,3 +1,5 @@
+use crate::ElectionConfig;
+
 use super::{
     call::CallMessage,
     query::{GetResultResponse, QueryMessage},
@@ -8,7 +10,7 @@ use sov_modules_api::Address;
 
 use sov_modules_api::{
     default_context::{DefaultContext, ZkDefaultContext},
-    default_signature::{private_key::DefaultPrivateKey, DefaultPublicKey},
+    default_signature::private_key::DefaultPrivateKey,
     Context, Module, ModuleInfo, PublicKey,
 };
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
@@ -34,7 +36,8 @@ fn test_module<C: Context>(admin: C::Address, working_set: &mut WorkingSet<C::St
 
     // Init module
     {
-        election.genesis(&admin, working_set).unwrap();
+        let config = ElectionConfig { admin };
+        election.genesis(&config, working_set).unwrap();
     }
 
     // Send candidates

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -1,16 +1,15 @@
 use super::ValueSetter;
-use anyhow::{anyhow, Result};
-use sov_modules_api::PublicKey;
+use anyhow::Result;
 use sov_state::WorkingSet;
 
 impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
-    pub(crate) fn init_module(&self, working_set: &mut WorkingSet<C::Storage>) -> Result<()> {
-        let admin_pub_key = C::PublicKey::try_from("value_setter_admin")
-            .map_err(|_| anyhow!("Admin initialization failed"))?;
-
-        self.admin
-            .set(admin_pub_key.to_address::<C::Address>(), working_set);
+    pub(crate) fn init_module(
+        &self,
+        admin_address: &<Self as sov_modules_api::Module>::Config,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<()> {
+        self.admin.set(admin_address.clone(), working_set);
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/genesis.rs
@@ -6,10 +6,10 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
     /// Initializes module with the `admin` role.
     pub(crate) fn init_module(
         &self,
-        admin_address: &<Self as sov_modules_api::Module>::Config,
+        admin_config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(admin_address.clone(), working_set);
+        self.admin.set(admin_config.admin.clone(), working_set);
         Ok(())
     }
 }

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -11,6 +11,10 @@ use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
 
+pub struct ValueSetterConfig<C: sov_modules_api::Context> {
+    pub admin: C::Address,
+}
+
 /// A new module:
 /// - Must derive `ModuleInfo`
 /// - Must contain `[address]` field
@@ -33,7 +37,7 @@ pub struct ValueSetter<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueSetter<C> {
     type Context = C;
 
-    type Config = C::Address;
+    type Config = ValueSetterConfig<C>;
 
     type CallMessage = call::CallMessage;
 

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/lib.rs
@@ -33,7 +33,7 @@ pub struct ValueSetter<C: sov_modules_api::Context> {
 impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueSetter<C> {
     type Context = C;
 
-    type Config = ();
+    type Config = C::Address;
 
     type CallMessage = call::CallMessage;
 
@@ -42,11 +42,11 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for ValueSetter<C> {
 
     fn genesis(
         &self,
-        _config: &Self::Config,
+        config: &Self::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(), Error> {
         // The initialization logic
-        Ok(self.init_module(working_set)?)
+        Ok(self.init_module(config, working_set)?)
     }
 
     fn call(

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -2,37 +2,39 @@ use super::ValueSetter;
 use crate::{call, query};
 
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
-use sov_modules_api::default_signature::DefaultPublicKey;
-use sov_modules_api::{Address, Context, PublicKey, Spec};
+use sov_modules_api::{Address, Context};
 use sov_modules_api::{Module, ModuleInfo};
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
-    let sender = DefaultPublicKey::from("value_setter_admin")
-        .to_address::<<DefaultContext as Spec>::Address>();
+    let sender = Address::from([1; 32]);
     let mut working_set = WorkingSet::new(ProverStorage::temporary());
 
     // Test Native-Context
     {
         let context = DefaultContext::new(sender.clone());
-        test_value_setter_helper(context, &mut working_set);
+        test_value_setter_helper(context, &sender, &mut working_set);
     }
 
     let (_, witness) = working_set.freeze();
 
     // Test Zk-Context
     {
-        let zk_context = ZkDefaultContext::new(sender);
+        let zk_context = ZkDefaultContext::new(sender.clone());
         let mut zk_working_set = WorkingSet::with_witness(ZkStorage::new([0u8; 32]), witness);
-        test_value_setter_helper(zk_context, &mut zk_working_set);
+        test_value_setter_helper(zk_context, &sender, &mut zk_working_set);
     }
 }
 
-fn test_value_setter_helper<C: Context>(context: C, working_set: &mut WorkingSet<C::Storage>) {
+fn test_value_setter_helper<C: Context>(
+    context: C,
+    sender: &C::Address,
+    working_set: &mut WorkingSet<C::Storage>,
+) {
     let module = ValueSetter::<C>::new();
-    module.genesis(&(), working_set).unwrap();
+    module.genesis(sender, working_set).unwrap();
 
     let new_value = 99;
     let call_msg = call::CallMessage::SetValue(new_value);
@@ -62,14 +64,16 @@ fn test_value_setter_helper<C: Context>(context: C, working_set: &mut WorkingSet
 
 #[test]
 fn test_err_on_sender_is_not_admin() {
-    let sender: Address = Address::try_from([9u8; 32].as_ref()).unwrap();
+    let sender = Address::from([1; 32]);
+
     let backing_store = ProverStorage::temporary();
     let native_working_set = &mut WorkingSet::new(backing_store);
 
+    let sender_not_admin = Address::from([2; 32]);
     // Test Native-Context
     {
         let context = DefaultContext::new(sender.clone());
-        test_err_on_sender_is_not_admin_helper(context, native_working_set);
+        test_err_on_sender_is_not_admin_helper(context, &sender_not_admin, native_working_set);
     }
     let (_, witness) = native_working_set.freeze();
 
@@ -78,16 +82,17 @@ fn test_err_on_sender_is_not_admin() {
         let zk_backing_store = ZkStorage::new([0u8; 32]);
         let zk_context = ZkDefaultContext::new(sender);
         let zk_working_set = &mut WorkingSet::with_witness(zk_backing_store, witness);
-        test_err_on_sender_is_not_admin_helper(zk_context, zk_working_set);
+        test_err_on_sender_is_not_admin_helper(zk_context, &sender_not_admin, zk_working_set);
     }
 }
 
 fn test_err_on_sender_is_not_admin_helper<C: Context>(
     context: C,
+    sender: &C::Address,
     working_set: &mut WorkingSet<C::Storage>,
 ) {
     let module = ValueSetter::<C>::new();
-    module.genesis(&(), working_set).unwrap();
+    module.genesis(sender, working_set).unwrap();
     let resp = module.set_value(11, &context, working_set);
 
     assert!(resp.is_err());

--- a/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
+++ b/sov-modules/sov-modules-impl/examples/value-setter/src/tests.rs
@@ -1,5 +1,5 @@
 use super::ValueSetter;
-use crate::{call, query};
+use crate::{call, query, ValueSetterConfig};
 
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::{Address, Context};
@@ -9,32 +9,37 @@ use sovereign_sdk::stf::Event;
 
 #[test]
 fn test_value_setter() {
-    let sender = Address::from([1; 32]);
     let mut working_set = WorkingSet::new(ProverStorage::temporary());
-
+    let admin = Address::from([1; 32]);
     // Test Native-Context
     {
-        let context = DefaultContext::new(sender.clone());
-        test_value_setter_helper(context, &sender, &mut working_set);
+        let config = ValueSetterConfig {
+            admin: admin.clone(),
+        };
+        let context = DefaultContext::new(admin.clone());
+        test_value_setter_helper(context, &config, &mut working_set);
     }
 
     let (_, witness) = working_set.freeze();
 
     // Test Zk-Context
     {
-        let zk_context = ZkDefaultContext::new(sender.clone());
+        let config = ValueSetterConfig {
+            admin: admin.clone(),
+        };
+        let zk_context = ZkDefaultContext::new(admin);
         let mut zk_working_set = WorkingSet::with_witness(ZkStorage::new([0u8; 32]), witness);
-        test_value_setter_helper(zk_context, &sender, &mut zk_working_set);
+        test_value_setter_helper(zk_context, &config, &mut zk_working_set);
     }
 }
 
 fn test_value_setter_helper<C: Context>(
     context: C,
-    sender: &C::Address,
+    config: &ValueSetterConfig<C>,
     working_set: &mut WorkingSet<C::Storage>,
 ) {
     let module = ValueSetter::<C>::new();
-    module.genesis(sender, working_set).unwrap();
+    module.genesis(config, working_set).unwrap();
 
     let new_value = 99;
     let call_msg = call::CallMessage::SetValue(new_value);
@@ -72,27 +77,33 @@ fn test_err_on_sender_is_not_admin() {
     let sender_not_admin = Address::from([2; 32]);
     // Test Native-Context
     {
+        let config = ValueSetterConfig {
+            admin: sender_not_admin.clone(),
+        };
         let context = DefaultContext::new(sender.clone());
-        test_err_on_sender_is_not_admin_helper(context, &sender_not_admin, native_working_set);
+        test_err_on_sender_is_not_admin_helper(context, &config, native_working_set);
     }
     let (_, witness) = native_working_set.freeze();
 
     // Test Zk-Context
     {
+        let config = ValueSetterConfig {
+            admin: sender_not_admin,
+        };
         let zk_backing_store = ZkStorage::new([0u8; 32]);
         let zk_context = ZkDefaultContext::new(sender);
         let zk_working_set = &mut WorkingSet::with_witness(zk_backing_store, witness);
-        test_err_on_sender_is_not_admin_helper(zk_context, &sender_not_admin, zk_working_set);
+        test_err_on_sender_is_not_admin_helper(zk_context, &config, zk_working_set);
     }
 }
 
 fn test_err_on_sender_is_not_admin_helper<C: Context>(
     context: C,
-    sender: &C::Address,
+    config: &ValueSetterConfig<C>,
     working_set: &mut WorkingSet<C::Storage>,
 ) {
     let module = ValueSetter::<C>::new();
-    module.genesis(sender, working_set).unwrap();
+    module.genesis(config, working_set).unwrap();
     let resp = module.set_value(11, &context, working_set);
 
     assert!(resp.is_err());

--- a/sov-modules/sov-modules-impl/sequencer/src/tests.rs
+++ b/sov-modules/sov-modules-impl/sequencer/src/tests.rs
@@ -1,5 +1,6 @@
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Module, ModuleInfo, PublicKey, Spec};
+use sov_modules_api::Hasher;
+use sov_modules_api::{Address, Module, ModuleInfo, Spec};
 use sov_state::{ProverStorage, WorkingSet};
 
 use crate::hooks::Hooks;
@@ -53,8 +54,7 @@ impl TestSequencer {
 }
 
 fn create_bank_config() -> (bank::BankConfig<C>, <C as Spec>::Address) {
-    let pub_key = <C as Spec>::PublicKey::try_from("seq_pub_key").unwrap();
-    let seq_address = pub_key.to_address::<<C as Spec>::Address>();
+    let seq_address = generate_address("seq_pub_key");
 
     let token_config = bank::TokenConfig {
         token_name: "InitialToken".to_owned(),
@@ -145,4 +145,9 @@ fn test_sequencer() {
         let resp = test_sequencer.query_balance_via_sequencer(working_set);
         assert_eq!(INITIAL_BALANCE, resp.data.unwrap().balance);
     }
+}
+
+pub fn generate_address(key: &str) -> <C as Spec>::Address {
+    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    Address::from(hash)
 }


### PR DESCRIPTION
This PR introduces the following changes:
1. `ed25519_dalek` for default signature scheme
2. transactions in tests are now signed with the private key
3. genesis `Config` for `ValueSetter` & `Election` modules
4. `create_config` refactoring (before, we had two functions with similar logic)