### PR TITLE
Disable patch coverage check for now

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,6 +10,7 @@ coverage:
       default:
         # Avoid false negatives
         threshold: 1%
+    patch: off
 
 # Test files aren't important for coverage
 ignore:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run cargo fmt check
         run: |
           if ! cargo fmt --check ; then
-            echo "Formatting errors detected, please rune `cargo fmt` to fix it";
+            echo "Formatting errors detected, please run 'cargo fmt' to fix it";
             exit 1
           fi
 


### PR DESCRIPTION
Should prevent failures of CI when total coverage hasn't been go below required threshold, but "path" coverage did.


Should be enabled later to have better checks for new PRs