### PR TITLE
Manually prefix Bank/Token

### DIFF
--- a/sov-modules/sov-modules-impl/bank/src/call.rs
+++ b/sov-modules/sov-modules-impl/bank/src/call.rs
@@ -48,11 +48,16 @@ impl<C: sov_modules_api::Context> Bank<C> {
             &[(minter_address, initial_balance)],
             context.sender().as_ref(),
             salt,
+            self.tokens.prefix(),
             working_set,
         )?;
 
         if self.tokens.get(&token_address, working_set).is_some() {
-            bail!("Token address already exists");
+            bail!(
+                "Token {} at {} address already exists",
+                token_name,
+                token_address
+            );
         }
 
         self.tokens.set(&token_address, token, working_set);
@@ -97,8 +102,11 @@ impl<C: sov_modules_api::Context> Bank<C> {
     }
 }
 
-pub(crate) fn prefix_from_address<C: sov_modules_api::Context>(
+pub(crate) fn prefix_from_address_with_parent<C: sov_modules_api::Context>(
+    parent_prefix: &sov_state::Prefix,
     token_address: &C::Address,
 ) -> sov_state::Prefix {
-    sov_state::Prefix::new(token_address.as_ref().to_vec())
+    let mut prefix = parent_prefix.as_aligned_vec().clone().into_inner();
+    prefix.extend_from_slice(format!("{}", token_address).as_bytes());
+    sov_state::Prefix::new(prefix)
 }

--- a/sov-modules/sov-modules-impl/bank/src/genesis.rs
+++ b/sov-modules/sov-modules-impl/bank/src/genesis.rs
@@ -11,12 +11,14 @@ impl<C: sov_modules_api::Context> Bank<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
+        let parent_prefix = self.tokens.prefix();
         for token_config in config.tokens.iter() {
             let (token_address, token) = Token::<C>::create(
                 &token_config.token_name,
                 &token_config.address_and_balances,
                 &DEPLOYER,
                 SALT,
+                parent_prefix,
                 working_set,
             )?;
 

--- a/sov-modules/sov-modules-impl/bank/src/token.rs
+++ b/sov-modules/sov-modules-impl/bank/src/token.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Result};
 use sov_modules_api::CallResponse;
-use sov_state::WorkingSet;
+use sov_state::{Prefix, WorkingSet};
 
-use crate::call::prefix_from_address;
+use crate::call::prefix_from_address_with_parent;
 
 pub type Amount = u64;
 
@@ -78,11 +78,12 @@ impl<C: sov_modules_api::Context> Token<C> {
         address_and_balances: &[(C::Address, u64)],
         sender: &[u8],
         salt: u64,
+        parent_prefix: &Prefix,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(C::Address, Self)> {
         let token_address = super::create_token_address::<C>(token_name, sender, salt);
 
-        let token_prefix = prefix_from_address::<C>(&token_address);
+        let token_prefix = prefix_from_address_with_parent::<C>(parent_prefix, &token_address);
         let balances = sov_state::StateMap::new(token_prefix);
 
         let mut total_supply: Option<u64> = Some(0);

--- a/sov-modules/sov-modules-impl/bank/tests/burn_test.rs
+++ b/sov-modules/sov-modules-impl/bank/tests/burn_test.rs
@@ -1,5 +1,3 @@
-use borsh::BorshSerialize;
-
 use bank::call::CallMessage;
 use bank::genesis::{DEPLOYER, SALT};
 use bank::query::{BalanceResponse, QueryMessage, TotalSupplyResponse};
@@ -90,14 +88,13 @@ fn burn_deployed_tokens() {
     let failed_to_burn = bank.call(burn_message, &sender_context, &mut working_set);
     assert!(failed_to_burn.is_err());
     let expected_error = format!(
-        "Value not found for prefix: 0x{}",
-        hex::encode(token_address.try_to_vec().unwrap())
+        "Value not found for prefix: \"bank/Bank/tokens/{}",
+        token_address
     );
-    assert!(failed_to_burn
-        .err()
-        .unwrap()
-        .to_string()
-        .contains(&expected_error));
+    let actual_msg = failed_to_burn.err().unwrap().to_string();
+    println!("EXPECTED: {}", &expected_error);
+    println!("ACTUAL  : {}", &actual_msg);
+    assert!(actual_msg.contains(&expected_error));
     let current_total_supply = query_total_supply(&mut working_set);
     assert_eq!(previous_total_supply, current_total_supply);
     let sender_balance = query_user_balance(sender_address, &mut working_set);

--- a/sov-modules/sov-modules-impl/bank/tests/burn_test.rs
+++ b/sov-modules/sov-modules-impl/bank/tests/burn_test.rs
@@ -92,8 +92,6 @@ fn burn_deployed_tokens() {
         token_address
     );
     let actual_msg = failed_to_burn.err().unwrap().to_string();
-    println!("EXPECTED: {}", &expected_error);
-    println!("ACTUAL  : {}", &actual_msg);
     assert!(actual_msg.contains(&expected_error));
     let current_total_supply = query_total_supply(&mut working_set);
     assert_eq!(previous_total_supply, current_total_supply);

--- a/sov-modules/sov-modules-impl/bank/tests/transfer_test.rs
+++ b/sov-modules/sov-modules-impl/bank/tests/transfer_test.rs
@@ -146,12 +146,12 @@ fn transfer_initial_token() {
         assert!(result.is_err());
         let error = result.err().unwrap();
 
-        let expected_message_part = format!("Value not found for prefix: 0xc166b1b9c394ac408de38dd16fdba54edfcb3f7502f42ed59f296b93216f34f4 and: storage key");
+        let expected_message_part = format!(
+            "Value not found for prefix: \"bank/Bank/tokens/{}\" and: storage key",
+            token_address
+        );
         let actual_message = error.to_string();
-        println!("expected_message: {}", expected_message_part);
-        println!("actual_message  : {}", actual_message);
-        // TODO: Prefix just address https://github.com/Sovereign-Labs/sovereign/issues/185
-        assert!(false);
+        assert!(actual_message.contains(&expected_message_part));
 
         let receiver_balance_after = query_user_balance(receiver_address, &mut working_set);
         assert_eq!(receiver_balance_before, receiver_balance_after);

--- a/sov-modules/sov-modules-impl/bank/tests/transfer_test.rs
+++ b/sov-modules/sov-modules-impl/bank/tests/transfer_test.rs
@@ -144,12 +144,14 @@ fn transfer_initial_token() {
 
         let result = bank.call(transfer_message, &unknown_sender_context, &mut working_set);
         assert!(result.is_err());
-
         let error = result.err().unwrap();
+
+        let expected_message_part = format!("Value not found for prefix: 0xc166b1b9c394ac408de38dd16fdba54edfcb3f7502f42ed59f296b93216f34f4 and: storage key");
+        let actual_message = error.to_string();
+        println!("expected_message: {}", expected_message_part);
+        println!("actual_message  : {}", actual_message);
         // TODO: Prefix just address https://github.com/Sovereign-Labs/sovereign/issues/185
-        assert!(error
-            .to_string()
-            .contains("Value not found for prefix: 0xc166b1b9c394ac408de38dd16fdba54edfcb3f7502f42ed59f296b93216f34f4 and: storage key"));
+        assert!(false);
 
         let receiver_balance_after = query_user_balance(receiver_address, &mut working_set);
         assert_eq!(receiver_balance_before, receiver_balance_after);

--- a/sov-modules/sov-state/Cargo.toml
+++ b/sov-modules/sov-state/Cargo.toml
@@ -5,13 +5,12 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-# TODO remove this dependency once the  Decode/Encode traits are extracted to a separate crate.
+
 anyhow = { workspace = true }
 borsh = { workspace = true}
 serde = { workspace = true }
 thiserror = { workspace = true }
 sovereign-db = { path = "../../db/sovereign-db", optional = true}
-sovereign-sdk = { path = "../../sdk" }
 first-read-last-write-cache = { path = "../../first-read-last-write-cache" }
 jmt = { workspace = true }
 hex = { workspace = true}

--- a/sov-modules/sov-state/src/lib.rs
+++ b/sov-modules/sov-state/src/lib.rs
@@ -67,7 +67,7 @@ impl Prefix {
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.prefix.is_empty()
     }
 }
 


### PR DESCRIPTION
# Scope

This PR implements a fix for token balances not having a bank prefix. This is not final solution for overall case of nested structures prefixing.

Also, token prefix is generated as string, so it can be read by human.

Resolved #185 