### PR TITLE
Remove outdated readme form `module-system`

### DIFF
--- a/module-system/README.md
+++ b/module-system/README.md
@@ -1,9 +1,0 @@
-# sov-module
-
-This is a repository containing crates related to the Sovereign module system:
-
-1. `sov-state`: State management.
-2. `sov-modules-api`: Api for building a new Sovereign module.
-3. `module-implementations/`: Implementation of the standard modules.
-
-It is work in progress. The documentation will be provided once the Api stabilizes.


### PR DESCRIPTION
This PR removes an outdated readme. Now we have `crate-level` readmes. 