### PR TITLE
Add dev tools to Makefile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
-        run: cargo hack --feature-powerset check
+        run: make check-features
   test:
     runs-on: ubuntu-latest
     env:
@@ -80,7 +80,7 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo llvm-cov
-        run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
+        run: make coverage
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,26 @@
-
 install-dev-tools:
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
 	cargo install cargo-udeps
-
+	cargo install flaky-finder
 
 fix-checks: export RUSTFLAGS := -D warnings
 fix-checks:
 	cargo fmt --all
 	cargo fix --allow-dirty
 
+
+lint: export RUSTFLAGS := -D warnings
 lint:
-lint: export RUSTFLAGS := -D warnings:
 	cargo check
 	cargo clippy --all
 
 check-features:
 	cargo hack --feature-powerset check
 
+# Note: requires nightly
 unused-dependencies:
-	cargo +nightly udeps --all-targets
+	cargo udeps --all-targets
 
 flaky-finder:
 	flaky-finder -j16 -r320 --continue "cargo test -- --nocapture"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ fix-checks:
 	cargo fix --allow-dirty
 
 
-lint: export RUSTFLAGS := -D warnings
 lint:
 	cargo check
 	cargo clippy --all

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,44 @@
-install-dev-tools:
+.PHONY: help
+
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Build the the project
+	@cargo build
+
+clean: ## Cleans compiled
+	@cargo clean
+
+test: ## Runs test suite
+	cargo test
+
+install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
 	cargo install cargo-udeps
 	cargo install flaky-finder
 
-fix-checks: export RUSTFLAGS := -D warnings
-fix-checks:
+fix: export RUSTFLAGS := -D warnings
+fix:  ## cargo fmt and fix
 	cargo fmt --all
 	cargo fix --allow-dirty
 
 
-lint:
+lint:  ## cargo check and clippy
 	cargo check
 	cargo clippy --all
 
-check-features:
+check-features: ## Checks that project compiles with all combinations of features
 	cargo hack --feature-powerset check
 
-# Note: requires nightly
-unused-dependencies:
+find-unused-deps: ## Prints unused dependencies for project. Note: requires nightly
 	cargo udeps --all-targets
 
-flaky-finder:
+find-flaky-tests:  ## Runs tests over and over to find if there's flaky tests
 	flaky-finder -j16 -r320 --continue "cargo test -- --nocapture"
 
-coverage:
+coverage: ## Coverage in lcov format
 	cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
 
-coverage-html:
+coverage-html: ## Coverage in HTML format
 	cargo llvm-cov --locked --all-features --html

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,31 @@
 
 install-dev-tools:
 	cargo install cargo-llvm-cov
+	cargo install cargo-hack
+	cargo install cargo-udeps
 
-check: export RUSTFLAGS := -D warnings
-check:
-	cargo fmt
+
+fix-checks: export RUSTFLAGS := -D warnings
+fix-checks:
+	cargo fmt --all
+	cargo fix --allow-dirty
+
+lint:
+lint: export RUSTFLAGS := -D warnings:
 	cargo check
-	# Disabled until whole code base is checked
-	#cargo clippy
+	cargo clippy --all
 
+check-features:
+	cargo hack --feature-powerset check
+
+unused-dependencies:
+	cargo +nightly udeps --all-targets
+
+flaky-finder:
+	flaky-finder -j16 -r320 --continue "cargo test -- --nocapture"
 
 coverage:
+	cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
+
+coverage-html:
 	cargo llvm-cov --locked --all-features --html

--- a/adapters/celestia/src/types.rs
+++ b/adapters/celestia/src/types.rs
@@ -135,7 +135,7 @@ impl CelestiaHeader {
             .data_hash
             .as_ref()
             .ok_or(ValidationError::MissingDataHash)?;
-        if &root != &data_hash.0 {
+        if root != data_hash.0 {
             return Err(ValidationError::InvalidDataRoot);
         }
         Ok(())

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -30,8 +30,7 @@ const SEQUENCER_DA_ADDRESS: [u8; 47] = [
 ];
 
 pub fn initialize_ledger(path: impl AsRef<std::path::Path>) -> LedgerDB {
-    let ledger_db = LedgerDB::with_path(path).expect("Ledger DB failed to open");
-    ledger_db
+    LedgerDB::with_path(path).expect("Ledger DB failed to open")
 }
 
 async fn start_rpc_server(module: RpcModule<()>, address: SocketAddr) {
@@ -117,7 +116,7 @@ async fn main() -> Result<(), anyhow::Error> {
         println!(
             "Requesting data for height {} and prev_state_root 0x{}",
             height,
-            hex::encode(&prev_state_root)
+            hex::encode(prev_state_root)
         );
 
         // Fetch the relevant subset of the next Celestia block

--- a/module-system/module-implementations/prover-incentives/src/genesis.rs
+++ b/module-system/module-implementations/prover-incentives/src/genesis.rs
@@ -11,7 +11,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
         anyhow::ensure!(
-            config.initial_provers.len() > 0,
+            !config.initial_provers.is_empty(),
             "At least one prover must be set at genesis!"
         );
 

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -62,7 +62,7 @@ impl Context for ZkDefaultContext {
 
 impl PublicKey for DefaultPublicKey {
     fn to_address<A: AddressTrait>(&self) -> A {
-        let pub_key_hash = <ZkDefaultContext as Spec>::Hasher::hash(&self.pub_key);
+        let pub_key_hash = <ZkDefaultContext as Spec>::Hasher::hash(self.pub_key);
         A::from(pub_key_hash)
     }
 }


### PR DESCRIPTION
Adds some helpers to Makefile, such as:

```
▸ make
help                           Display this help message
build                          Build the the project
clean                          Cleans compiled
test                           Runs test suite
install-dev-tools              Installs all necessary cargo helpers
fix                            cargo fmt and fix
lint                           cargo check and clippy
check-features                 Checks that project compiles with all combinations of features
find-unused-deps               Prints unused dependencies for project. Note: requires nightly
find-flaky-tests               Runs tests over and over to find if there's flaky tests
coverage                       Coverage in lcov format
coverage-html                  Coverage in HTML format
```

Plus some clippy fixes