### PR TITLE
mint and freeze tokens

### DIFF
--- a/examples/demo-stf/src/bank_cmd/test_data/create_token.json
+++ b/examples/demo-stf/src/bank_cmd/test_data/create_token.json
@@ -3,6 +3,7 @@
       "salt": 11,
       "token_name": "sov-test-token",
       "initial_balance": 1000,
-      "minter_address": "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6"
+      "minter_address": "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6",
+      "authorized_minters": ["sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6"]
     }
 }

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -43,7 +43,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         /// The amount of tokens to mint.
         coins: Coins<C>,
         /// Address to mint tokens to
-        minter_address: C::Address
+        minter_address: C::Address,
     },
 
     /// Freeze a token so that the supply is frozen
@@ -116,7 +116,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        let mint_response = token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
+        let mint_response =
+            token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
         token.total_supply += coins.amount;
         self.tokens.set(&coins.token_address, token, working_set);
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -105,11 +105,11 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        let burn_response = token.burn(context.sender(), coins.amount, working_set)?;
+        token.burn(context.sender(), coins.amount, working_set)?;
         token.total_supply -= coins.amount;
         self.tokens.set(&coins.token_address, token, working_set);
 
-        Ok(burn_response)
+        Ok(CallResponse::default())
     }
 
     pub(crate) fn mint(
@@ -120,11 +120,10 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        let mint_response =
-            token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
+        token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
         self.tokens.set(&coins.token_address, token, working_set);
 
-        Ok(mint_response)
+        Ok(CallResponse::default())
     }
 
     pub(crate) fn freeze(
@@ -134,10 +133,10 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&token_address, working_set)?;
-        let freeze_response = token.freeze(context.sender())?;
+        token.freeze(context.sender())?;
         self.tokens.set(&token_address, token, working_set);
 
-        Ok(freeze_response)
+        Ok(CallResponse::default())
     }
 }
 
@@ -150,7 +149,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        token.transfer(from, to, coins.amount, working_set)
+        token.transfer(from, to, coins.amount, working_set)?;
+        Ok(CallResponse::default())
     }
 }
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -130,7 +130,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&token_address, working_set)?;
-        let freeze_response = token.freeze(context.sender(), working_set)?;
+        let freeze_response = token.freeze(context.sender())?;
         self.tokens.set(&token_address, token, working_set);
 
         Ok(freeze_response)

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -42,6 +42,8 @@ pub enum CallMessage<C: sov_modules_api::Context> {
     Mint {
         /// The amount of tokens to mint.
         coins: Coins<C>,
+        /// Address to mint tokens to
+        minter_address: C::Address
     },
 }
 
@@ -103,11 +105,12 @@ impl<C: sov_modules_api::Context> Bank<C> {
     pub(crate) fn mint(
         &self,
         coins: Coins<C>,
+        minter_address: C::Address,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
-        let mint_response = token.mint(context.sender(), coins.amount, working_set)?;
+        let mint_response = token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
         token.total_supply += coins.amount;
         self.tokens.set(&coins.token_address, token, working_set);
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -37,6 +37,12 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         /// The amount of tokens to burn.
         coins: Coins<C>,
     },
+
+    /// Mints a specified amount of tokens.
+    Mint {
+        /// The amount of tokens to mint.
+        coins: Coins<C>,
+    },
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
@@ -92,6 +98,20 @@ impl<C: sov_modules_api::Context> Bank<C> {
         self.tokens.set(&coins.token_address, token, working_set);
 
         Ok(burn_response)
+    }
+
+    pub(crate) fn mint(
+        &self,
+        coins: Coins<C>,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse> {
+        let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
+        let mint_response = token.mint(context.sender(), coins.amount, working_set)?;
+        token.total_supply += coins.amount;
+        self.tokens.set(&coins.token_address, token, working_set);
+
+        Ok(mint_response)
     }
 }
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -20,8 +20,10 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         token_name: String,
         /// The initial balance of the new token.
         initial_balance: Amount,
-        /// The address of the account that minted new tokens.
+        /// The address of the account that the new tokens are minted to.
         minter_address: C::Address,
+        /// Authorized minter list.
+        authorized_minters: Option<Vec<C::Address>>,
     },
 
     /// Transfers a specified amount of tokens to the specified address.
@@ -60,12 +62,14 @@ impl<C: sov_modules_api::Context> Bank<C> {
         salt: u64,
         initial_balance: Amount,
         minter_address: C::Address,
+        authorized_minters: Option<Vec<C::Address>>,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         let (token_address, token) = Token::<C>::create(
             &token_name,
             &[(minter_address, initial_balance)],
+            authorized_minters,
             context.sender().as_ref(),
             salt,
             self.tokens.prefix(),

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -45,6 +45,12 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         /// Address to mint tokens to
         minter_address: C::Address
     },
+
+    /// Freeze a token so that the supply is frozen
+    Freeze {
+        /// Address of the token to be frozen
+        token_address: C::Address,
+    },
 }
 
 impl<C: sov_modules_api::Context> Bank<C> {
@@ -115,6 +121,19 @@ impl<C: sov_modules_api::Context> Bank<C> {
         self.tokens.set(&coins.token_address, token, working_set);
 
         Ok(mint_response)
+    }
+
+    pub(crate) fn freeze(
+        &self,
+        token_address: C::Address,
+        context: &C,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse> {
+        let mut token = self.tokens.get_or_err(&token_address, working_set)?;
+        let freeze_response = token.freeze(context.sender(), working_set)?;
+        self.tokens.set(&token_address, token, working_set);
+
+        Ok(freeze_response)
     }
 }
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -122,7 +122,6 @@ impl<C: sov_modules_api::Context> Bank<C> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
         let mint_response =
             token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
-        token.total_supply += coins.amount;
         self.tokens.set(&coins.token_address, token, working_set);
 
         Ok(mint_response)

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -23,7 +23,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
         /// The address of the account that the new tokens are minted to.
         minter_address: C::Address,
         /// Authorized minter list.
-        authorized_minters: Option<Vec<C::Address>>,
+        authorized_minters: Vec<C::Address>,
     },
 
     /// Transfers a specified amount of tokens to the specified address.
@@ -62,7 +62,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         salt: u64,
         initial_balance: Amount,
         minter_address: C::Address,
-        authorized_minters: Option<Vec<C::Address>>,
+        authorized_minters: Vec<C::Address>,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {

--- a/module-system/module-implementations/sov-bank/src/genesis.rs
+++ b/module-system/module-implementations/sov-bank/src/genesis.rs
@@ -16,6 +16,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             let (token_address, token) = Token::<C>::create(
                 &token_config.token_name,
                 &token_config.address_and_balances,
+                None,
                 &DEPLOYER,
                 SALT,
                 parent_prefix,

--- a/module-system/module-implementations/sov-bank/src/genesis.rs
+++ b/module-system/module-implementations/sov-bank/src/genesis.rs
@@ -16,7 +16,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             let (token_address, token) = Token::<C>::create(
                 &token_config.token_name,
                 &token_config.address_and_balances,
-                None,
+                vec![C::Address::try_from(&DEPLOYER)?],
                 &DEPLOYER,
                 SALT,
                 parent_prefix,

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -79,6 +79,8 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             }
 
             call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
+
+            call::CallMessage::Mint { coins } => Ok(self.mint(coins, context, working_set)?),
         }
     }
 }

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -81,6 +81,8 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
 
             call::CallMessage::Mint { coins, minter_address } => Ok(self.mint(coins, minter_address, context, working_set)?),
+
+            call::CallMessage::Freeze { token_address } => Ok(self.freeze(token_address, context, working_set)?),
         }
     }
 }

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -80,7 +80,7 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
 
             call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
 
-            call::CallMessage::Mint { coins } => Ok(self.mint(coins, context, working_set)?),
+            call::CallMessage::Mint { coins, minter_address } => Ok(self.mint(coins, minter_address, context, working_set)?),
         }
     }
 }

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -65,11 +65,13 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
                 token_name,
                 initial_balance,
                 minter_address,
+                authorized_minters,
             } => Ok(self.create_token(
                 token_name,
                 salt,
                 initial_balance,
                 minter_address,
+                authorized_minters,
                 context,
                 working_set,
             )?),

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -80,9 +80,14 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
 
             call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
 
-            call::CallMessage::Mint { coins, minter_address } => Ok(self.mint(coins, minter_address, context, working_set)?),
+            call::CallMessage::Mint {
+                coins,
+                minter_address,
+            } => Ok(self.mint(coins, minter_address, context, working_set)?),
 
-            call::CallMessage::Freeze { token_address } => Ok(self.freeze(token_address, context, working_set)?),
+            call::CallMessage::Freeze { token_address } => {
+                Ok(self.freeze(token_address, context, working_set)?)
+            }
         }
     }
 }

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use sov_modules_api::{CallResponse};
+use sov_modules_api::CallResponse;
 use sov_state::{Prefix, WorkingSet};
 
 use crate::call::prefix_from_address_with_parent;
@@ -66,10 +66,7 @@ impl<C: sov_modules_api::Context> Token<C> {
         Ok(CallResponse::default())
     }
 
-    pub(crate) fn freeze(
-        &mut self,
-        sender: &C::Address,
-    ) -> Result<CallResponse> {
+    pub(crate) fn freeze(&mut self, sender: &C::Address) -> Result<CallResponse> {
         self.is_authorized_minter(sender)?;
         if self.frozen {
             bail!("Token is already frozen")
@@ -89,17 +86,18 @@ impl<C: sov_modules_api::Context> Token<C> {
         if self.frozen {
             bail!("Attempt to mint frozen token")
         }
-        let to_balance = self.balances.get(minter_address, working_set).unwrap_or_default() + amount;
+        let to_balance = self
+            .balances
+            .get(minter_address, working_set)
+            .unwrap_or_default()
+            + amount;
         self.balances.set(minter_address, to_balance, working_set);
         Ok(CallResponse::default())
     }
 
-    fn is_authorized_minter(
-        &self,
-        sender: &C::Address,
-    ) -> Result<()> {
+    fn is_authorized_minter(&self, sender: &C::Address) -> Result<()> {
         if !self.authorized_minters.contains(sender) {
-            bail!("Sender {} is not an authorized minter",sender)
+            bail!("Sender {} is not an authorized minter", sender)
         }
         Ok(())
     }

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -66,6 +66,19 @@ impl<C: sov_modules_api::Context> Token<C> {
         Ok(CallResponse::default())
     }
 
+    pub(crate) fn freeze(
+        &mut self,
+        sender: &C::Address,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Result<CallResponse> {
+        self.is_authorized_minter(sender)?;
+        if self.frozen {
+            bail!("Token is already frozen")
+        }
+        self.frozen = true;
+        Ok(CallResponse::default())
+    }
+
     pub(crate) fn mint(
         &mut self,
         sender: &C::Address,
@@ -87,7 +100,7 @@ impl<C: sov_modules_api::Context> Token<C> {
         sender: &C::Address,
     ) -> Result<()> {
         if !self.authorized_minters.contains(sender) {
-            bail!("Sender {} is not authorized to mint",sender)
+            bail!("Sender {} is not an authorized minter",sender)
         }
         Ok(())
     }

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -69,7 +69,6 @@ impl<C: sov_modules_api::Context> Token<C> {
     pub(crate) fn freeze(
         &mut self,
         sender: &C::Address,
-        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         self.is_authorized_minter(sender)?;
         if self.frozen {

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use sov_modules_api::CallResponse;
 use sov_state::{Prefix, WorkingSet};
+use std::collections::HashSet;
 
 use crate::call::prefix_from_address_with_parent;
 
@@ -26,9 +27,12 @@ pub(crate) struct Token<C: sov_modules_api::Context> {
     pub(crate) total_supply: u64,
     /// Mapping from user address to user balance.
     pub(crate) balances: sov_state::StateMap<C::Address, Amount>,
-    /// Flag indicating if the supply is frozen.
-    pub(crate) frozen: bool,
-    /// Flag indicating if the supply is frozen.
+
+    /// Vector containing the authorized minters
+    /// Empty vector indicates that the token supply is frozen
+    /// Non empty vector indicates members of the vector can mint.
+    /// Freezing a token requires emptying the vector
+    /// NOTE: This is explicit so if a creator doesn't add themselves, then they can't mint
     pub(crate) authorized_minters: Vec<C::Address>,
 }
 
@@ -66,12 +70,15 @@ impl<C: sov_modules_api::Context> Token<C> {
         Ok(CallResponse::default())
     }
 
+    /// Freezing a token requires emptying the authorized_minter vector
+    /// authorized_minter: Vec<Address> is used to determine if the token is frozen or not
+    /// If the vector is empty when the function is called, this means the token is already frozen
     pub(crate) fn freeze(&mut self, sender: &C::Address) -> Result<CallResponse> {
-        self.is_authorized_minter(sender)?;
-        if self.frozen {
+        if self.authorized_minters.is_empty() {
             bail!("Token is already frozen")
         }
-        self.frozen = true;
+        self.is_authorized_minter(sender)?;
+        self.authorized_minters = vec![];
         Ok(CallResponse::default())
     }
 
@@ -82,10 +89,10 @@ impl<C: sov_modules_api::Context> Token<C> {
         amount: Amount,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        self.is_authorized_minter(sender)?;
-        if self.frozen {
+        if self.authorized_minters.is_empty() {
             bail!("Attempt to mint frozen token")
         }
+        self.is_authorized_minter(sender)?;
         let to_balance = self
             .balances
             .get(minter_address, working_set)
@@ -122,19 +129,17 @@ impl<C: sov_modules_api::Context> Token<C> {
     pub(crate) fn create(
         token_name: &str,
         address_and_balances: &[(C::Address, u64)],
-        authorized_minters: Option<Vec<C::Address>>,
+        authorized_minters: Vec<C::Address>,
         sender: &[u8],
         salt: u64,
         parent_prefix: &Prefix,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<(C::Address, Self)> {
         let token_address = super::create_token_address::<C>(token_name, sender, salt);
-        let frozen = false;
         let token_prefix = prefix_from_address_with_parent::<C>(parent_prefix, &token_address);
         let balances = sov_state::StateMap::new(token_prefix);
 
         let mut total_supply: Option<u64> = Some(0);
-
         for (address, balance) in address_and_balances.iter() {
             balances.set(address, *balance, working_set);
             total_supply = total_supply.and_then(|ts| ts.checked_add(*balance));
@@ -144,17 +149,20 @@ impl<C: sov_modules_api::Context> Token<C> {
             Some(total_supply) => total_supply,
             None => bail!("Total supply overflow"),
         };
-        let mut auth_minter_list = authorized_minters.clone().unwrap_or_else(|| vec![]);
-        let sender_address = C::Address::try_from(sender)?;
-        if !auth_minter_list.contains(&sender_address) {
-            auth_minter_list.push(sender_address);
+
+        let mut indices = HashSet::new();
+        let mut auth_minter_list = Vec::new();
+
+        for (i, item) in authorized_minters.iter().enumerate() {
+            if indices.insert(item.as_ref()) {
+                auth_minter_list.push(authorized_minters[i].clone());
+            }
         }
 
         let token = Token::<C> {
             name: token_name.to_owned(),
             total_supply,
             balances,
-            frozen,
             authorized_minters: auth_minter_list,
         };
 

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -144,13 +144,18 @@ impl<C: sov_modules_api::Context> Token<C> {
             Some(total_supply) => total_supply,
             None => bail!("Total supply overflow"),
         };
+        let mut auth_minter_list = authorized_minters.clone().unwrap_or_else(|| vec![]);
+        let sender_address = C::Address::try_from(sender)?;
+        if !auth_minter_list.contains(&sender_address) {
+            auth_minter_list.push(sender_address);
+        }
 
         let token = Token::<C> {
             name: token_name.to_owned(),
             total_supply,
             balances,
             frozen,
-            authorized_minters: authorized_minters.unwrap_or(vec![C::Address::try_from(sender)?]),
+            authorized_minters: auth_minter_list,
         };
 
         Ok((token_address, token))

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use borsh::BorshSerialize;
 use sov_state::{Prefix, WorkingSet};
 use std::collections::HashSet;
 
@@ -150,14 +149,12 @@ impl<C: sov_modules_api::Context> Token<C> {
             None => bail!("Total supply overflow"),
         };
 
-        let mut seen = HashSet::with_capacity(authorized_minters.len());
-        let mut auth_minter_list = Vec::with_capacity(authorized_minters.len());
+        let mut indices = HashSet::new();
+        let mut auth_minter_list = Vec::new();
 
-        for item in authorized_minters {
-            let item_ref = item.try_to_vec()?;
-            if !seen.contains(&item_ref) {
-                seen.insert(item_ref);
-                auth_minter_list.push(item);
+        for (i, item) in authorized_minters.iter().enumerate() {
+            if indices.insert(item.as_ref()) {
+                auth_minter_list.push(authorized_minters[i].clone());
             }
         }
 

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -92,6 +92,7 @@ impl<C: sov_modules_api::Context> Token<C> {
             .unwrap_or_default()
             + amount;
         self.balances.set(minter_address, to_balance, working_set);
+        self.total_supply += amount;
         Ok(CallResponse::default())
     }
 

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -121,6 +121,7 @@ impl<C: sov_modules_api::Context> Token<C> {
     pub(crate) fn create(
         token_name: &str,
         address_and_balances: &[(C::Address, u64)],
+        authorized_minters: Option<Vec<C::Address>>,
         sender: &[u8],
         salt: u64,
         parent_prefix: &Prefix,
@@ -148,7 +149,7 @@ impl<C: sov_modules_api::Context> Token<C> {
             total_supply,
             balances,
             frozen,
-            authorized_minters: vec![C::Address::try_from(sender)?],
+            authorized_minters: authorized_minters.unwrap_or(vec![C::Address::try_from(sender)?]),
         };
 
         Ok((token_address, token))

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -36,7 +36,7 @@ fn burn_deployed_tokens() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![minter_address.clone()],
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -36,6 +36,7 @@ fn burn_deployed_tokens() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
+        authorized_minters: None,
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -26,7 +26,7 @@ fn initial_and_deployed_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![minter_address.clone()],
     };
 
     let create_token_response = bank

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -26,6 +26,7 @@ fn initial_and_deployed_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
+        authorized_minters: None,
     };
 
     let create_token_response = bank

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -55,11 +55,13 @@ fn freeze_token() {
         token_address: token_address.clone(),
     };
 
-    let freeze = bank
-        .call(freeze_message.clone(), &minter_context, &mut working_set);
+    let freeze = bank.call(freeze_message.clone(), &minter_context, &mut working_set);
     assert!(freeze.is_err());
 
-    assert_eq!("Token is already frozen".to_string(),freeze.err().unwrap().to_string());
+    assert_eq!(
+        "Token is already frozen".to_string(),
+        freeze.err().unwrap().to_string()
+    );
 
     // create a second token
     let token_name = "Token2".to_owned();
@@ -87,12 +89,17 @@ fn freeze_token() {
         token_address: token_address_2.clone(),
     };
 
-    let freeze = bank
-        .call(freeze_message.clone(), &unauthorized_context, &mut working_set);
+    let freeze = bank.call(
+        freeze_message.clone(),
+        &unauthorized_context,
+        &mut working_set,
+    );
     assert!(freeze.is_err());
-    let unauthorized_minter_msg = format!("Sender {} is not an authorized minter",
-                                          unauthorized_address);
-    assert_eq!(unauthorized_minter_msg,freeze.err().unwrap().to_string());
+    let unauthorized_minter_msg = format!(
+        "Sender {} is not an authorized minter",
+        unauthorized_address
+    );
+    assert_eq!(unauthorized_minter_msg, freeze.err().unwrap().to_string());
 
     // -----
     // Try to mint a frozen token
@@ -106,16 +113,20 @@ fn freeze_token() {
         minter_address: new_holder.clone(),
     };
 
-    let query_total_supply = |token_address:Address,working_set: &mut WorkingSet<Storage>| -> Option<u64> {
+    let query_total_supply = |token_address: Address,
+                              working_set: &mut WorkingSet<Storage>|
+     -> Option<u64> {
         let total_supply: TotalSupplyResponse = bank.supply_of(token_address.clone(), working_set);
         total_supply.amount
     };
 
-    let minted = bank
-        .call(mint_message.clone(), &minter_context, &mut working_set);
+    let minted = bank.call(mint_message.clone(), &minter_context, &mut working_set);
     assert!(minted.is_err());
 
-    assert_eq!("Attempt to mint frozen token".to_string(),minted.err().unwrap().to_string() );
+    assert_eq!(
+        "Attempt to mint frozen token".to_string(),
+        minted.err().unwrap().to_string()
+    );
 
     // -----
     // Try to mint an unfrozen token, sanity check
@@ -133,15 +144,16 @@ fn freeze_token() {
         .expect("Failed to mint token");
     assert!(minted.events.is_empty());
 
-    let total_supply = query_total_supply(token_address_2.clone(),&mut working_set);
+    let total_supply = query_total_supply(token_address_2.clone(), &mut working_set);
     assert_eq!(Some(initial_balance + mint_amount), total_supply);
 
-    let query_user_balance =
-        |token_address:Address,user_address: Address, working_set: &mut WorkingSet<Storage>| -> Option<u64> {
-            bank.get_balance_of(user_address, token_address.clone(), working_set)
-        };
+    let query_user_balance = |token_address: Address,
+                              user_address: Address,
+                              working_set: &mut WorkingSet<Storage>|
+     -> Option<u64> {
+        bank.get_balance_of(user_address, token_address.clone(), working_set)
+    };
     let bal = query_user_balance(token_address_2.clone(), minter_address, &mut working_set);
 
     assert_eq!(Some(110), bal);
-
 }

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -1,12 +1,9 @@
 use helpers::{generate_address, C};
 use sov_bank::call::CallMessage;
-use sov_bank::genesis::{DEPLOYER, SALT};
 use sov_bank::query::TotalSupplyResponse;
 use sov_bank::{create_token_address, Bank, BankConfig, Coins};
 use sov_modules_api::{Address, Context, Module, ModuleInfo};
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
-
-use crate::helpers::create_bank_config_with_token;
 
 mod helpers;
 
@@ -64,5 +61,87 @@ fn freeze_token() {
 
     assert_eq!("Token is already frozen".to_string(),freeze.err().unwrap().to_string());
 
+    // create a second token
+    let token_name = "Token2".to_owned();
+    let initial_balance = 100;
+    let token_address_2 = create_token_address::<C>(&token_name, minter_address.as_ref(), salt);
+
+    // ---
+    // Deploying second token
+    let mint_message = CallMessage::CreateToken {
+        salt,
+        token_name,
+        initial_balance,
+        minter_address: minter_address.clone(),
+    };
+    let minted = bank
+        .call(mint_message, &minter_context, &mut working_set)
+        .expect("Failed to mint token");
+    // No events at the moment. If there are, needs to be checked
+    assert!(minted.events.is_empty());
+
+    // Try to freeze with a non authorized minter
+    let unauthorized_address = generate_address("unauthorized_address");
+    let unauthorized_context = C::new(unauthorized_address.clone());
+    let freeze_message = CallMessage::Freeze {
+        token_address: token_address_2.clone(),
+    };
+
+    let freeze = bank
+        .call(freeze_message.clone(), &unauthorized_context, &mut working_set);
+    assert!(freeze.is_err());
+    let unauthorized_minter_msg = format!("Sender {} is not an authorized minter",
+                                          unauthorized_address);
+    assert_eq!(unauthorized_minter_msg,freeze.err().unwrap().to_string());
+
+    // -----
+    // Try to mint a frozen token
+    let mint_amount = 10;
+    let new_holder = generate_address("new_holder");
+    let mint_message = CallMessage::Mint {
+        coins: Coins {
+            amount: mint_amount,
+            token_address: token_address.clone(),
+        },
+        minter_address: new_holder.clone(),
+    };
+
+    let query_total_supply = |token_address:Address,working_set: &mut WorkingSet<Storage>| -> Option<u64> {
+        let total_supply: TotalSupplyResponse = bank.supply_of(token_address.clone(), working_set);
+        total_supply.amount
+    };
+
+    let minted = bank
+        .call(mint_message.clone(), &minter_context, &mut working_set);
+    assert!(minted.is_err());
+
+    assert_eq!("Attempt to mint frozen token".to_string(),minted.err().unwrap().to_string() );
+
+    // -----
+    // Try to mint an unfrozen token, sanity check
+    let mint_amount = 10;
+    let mint_message = CallMessage::Mint {
+        coins: Coins {
+            amount: mint_amount,
+            token_address: token_address_2.clone(),
+        },
+        minter_address: minter_address.clone(),
+    };
+
+    let minted = bank
+        .call(mint_message.clone(), &minter_context, &mut working_set)
+        .expect("Failed to mint token");
+    assert!(minted.events.is_empty());
+
+    let total_supply = query_total_supply(token_address_2.clone(),&mut working_set);
+    assert_eq!(Some(initial_balance + mint_amount), total_supply);
+
+    let query_user_balance =
+        |token_address:Address,user_address: Address, working_set: &mut WorkingSet<Storage>| -> Option<u64> {
+            bank.get_balance_of(user_address, token_address.clone(), working_set)
+        };
+    let bal = query_user_balance(token_address_2.clone(), minter_address, &mut working_set);
+
+    assert_eq!(Some(110), bal);
 
 }

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -33,11 +33,11 @@ fn freeze_token() {
         minter_address: minter_address.clone(),
         authorized_minters: vec![minter_address.clone()],
     };
-    let minted = bank
+    let _minted = bank
         .call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     // -----
     // Freeze
@@ -45,10 +45,10 @@ fn freeze_token() {
         token_address: token_address.clone(),
     };
 
-    let freeze = bank
+    let _freeze = bank
         .call(freeze_message.clone(), &minter_context, &mut working_set)
         .expect("Failed to freeze token");
-    assert!(freeze.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     // ----
     // Try to freeze an already frozen token
@@ -78,11 +78,11 @@ fn freeze_token() {
         minter_address: minter_address.clone(),
         authorized_minters: vec![minter_address.clone()],
     };
-    let minted = bank
+    let _minted = bank
         .call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     // Try to freeze with a non authorized minter
     let unauthorized_address = generate_address("unauthorized_address");
@@ -141,10 +141,10 @@ fn freeze_token() {
         minter_address: minter_address.clone(),
     };
 
-    let minted = bank
+    let _minted = bank
         .call(mint_message.clone(), &minter_context, &mut working_set)
         .expect("Failed to mint token");
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let total_supply = query_total_supply(token_address_2.clone(), &mut working_set);
     assert_eq!(Some(initial_balance + mint_amount), total_supply);

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -31,7 +31,7 @@ fn freeze_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![minter_address.clone()],
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)
@@ -47,7 +47,7 @@ fn freeze_token() {
 
     let freeze = bank
         .call(freeze_message.clone(), &minter_context, &mut working_set)
-        .expect("Failed to burn token");
+        .expect("Failed to freeze token");
     assert!(freeze.events.is_empty());
 
     // ----
@@ -76,7 +76,7 @@ fn freeze_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![minter_address.clone()],
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -31,6 +31,7 @@ fn freeze_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
+        authorized_minters: None,
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)
@@ -75,6 +76,7 @@ fn freeze_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
+        authorized_minters: None,
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -1,0 +1,68 @@
+use helpers::{generate_address, C};
+use sov_bank::call::CallMessage;
+use sov_bank::genesis::{DEPLOYER, SALT};
+use sov_bank::query::TotalSupplyResponse;
+use sov_bank::{create_token_address, Bank, BankConfig, Coins};
+use sov_modules_api::{Address, Context, Module, ModuleInfo};
+use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
+
+use crate::helpers::create_bank_config_with_token;
+
+mod helpers;
+
+pub type Storage = ProverStorage<DefaultStorageSpec>;
+
+#[test]
+fn freeze_token() {
+    let bank = Bank::<C>::new();
+    let mut working_set = WorkingSet::new(ProverStorage::temporary());
+    let empty_bank_config = BankConfig::<C> { tokens: vec![] };
+    bank.genesis(&empty_bank_config, &mut working_set).unwrap();
+
+    let minter_address = generate_address("minter");
+    let minter_context = C::new(minter_address.clone());
+
+    let salt = 0;
+    let token_name = "Token1".to_owned();
+    let initial_balance = 100;
+    let token_address = create_token_address::<C>(&token_name, minter_address.as_ref(), salt);
+
+    // ---
+    // Deploying token
+    let mint_message = CallMessage::CreateToken {
+        salt,
+        token_name,
+        initial_balance,
+        minter_address: minter_address.clone(),
+    };
+    let minted = bank
+        .call(mint_message, &minter_context, &mut working_set)
+        .expect("Failed to mint token");
+    // No events at the moment. If there are, needs to be checked
+    assert!(minted.events.is_empty());
+
+    // -----
+    // Freeze
+    let freeze_message = CallMessage::Freeze {
+        token_address: token_address.clone(),
+    };
+
+    let freeze = bank
+        .call(freeze_message.clone(), &minter_context, &mut working_set)
+        .expect("Failed to burn token");
+    assert!(freeze.events.is_empty());
+
+    // ----
+    // Try to freeze an already frozen token
+    let freeze_message = CallMessage::Freeze {
+        token_address: token_address.clone(),
+    };
+
+    let freeze = bank
+        .call(freeze_message.clone(), &minter_context, &mut working_set);
+    assert!(freeze.is_err());
+
+    assert_eq!("Token is already frozen".to_string(),freeze.err().unwrap().to_string());
+
+
+}

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -33,11 +33,11 @@ fn mint_token() {
         minter_address: minter_address.clone(),
         authorized_minters: vec![minter_address.clone()],
     };
-    let minted = bank
+    let _minted = bank
         .call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let query_total_supply = |token_address: Address,
                               working_set: &mut WorkingSet<Storage>|
@@ -66,10 +66,10 @@ fn mint_token() {
         minter_address: new_holder.clone(),
     };
 
-    let minted = bank
+    let _minted = bank
         .call(mint_message.clone(), &minter_context, &mut working_set)
         .expect("Failed to mint token");
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let total_supply = query_total_supply(token_address.clone(), &mut working_set);
     assert_eq!(Some(initial_balance + mint_amount), total_supply);
@@ -118,11 +118,11 @@ fn mint_token() {
             authorized_minter_address_2.clone(),
         ],
     };
-    let minted = bank
+    let _minted = bank
         .call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     // Try to mint new token with original token creator, in this case minter_context
     let mint_amount = 10;
@@ -136,7 +136,6 @@ fn mint_token() {
     };
 
     let minted = bank.call(mint_message.clone(), &minter_context, &mut working_set);
-    let supply = query_total_supply(token_address.clone(), &mut working_set);
     let err = format!(
         "Sender {} is not an authorized minter",
         minter_address.clone()
@@ -154,7 +153,7 @@ fn mint_token() {
         minter_address: new_holder.clone(),
     };
 
-    let minted = bank
+    let _minted = bank
         .call(
             mint_message.clone(),
             &authorized_minter_2_context,
@@ -162,7 +161,7 @@ fn mint_token() {
         )
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
     assert_eq!(Some(110), supply);
 
     // Try to mint new token with authorized sender 1
@@ -175,7 +174,7 @@ fn mint_token() {
         minter_address: new_holder.clone(),
     };
 
-    let minted = bank
+    let _minted = bank
         .call(
             mint_message.clone(),
             &authorized_minter_1_context,
@@ -183,6 +182,6 @@ fn mint_token() {
         )
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
     assert_eq!(Some(120), supply);
 }

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -31,7 +31,7 @@ fn mint_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![minter_address.clone()],
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)
@@ -113,10 +113,10 @@ fn mint_token() {
         token_name,
         initial_balance,
         minter_address: minter_address.clone(),
-        authorized_minters: Some(vec![
+        authorized_minters: vec![
             authorized_minter_address_1.clone(),
             authorized_minter_address_2.clone(),
-        ]),
+        ],
     };
     let minted = bank
         .call(mint_message, &minter_context, &mut working_set)
@@ -135,12 +135,14 @@ fn mint_token() {
         minter_address: new_holder.clone(),
     };
 
-    let minted = bank
-        .call(mint_message.clone(), &minter_context, &mut working_set)
-        .expect("Failed to mint token");
+    let minted = bank.call(mint_message.clone(), &minter_context, &mut working_set);
     let supply = query_total_supply(token_address.clone(), &mut working_set);
-    assert!(minted.events.is_empty());
-    assert_eq!(Some(110), supply);
+    let err = format!(
+        "Sender {} is not an authorized minter",
+        minter_address.clone()
+    );
+    assert!(minted.is_err());
+    assert_eq!(err, minted.err().unwrap().to_string());
 
     // Try to mint new token with authorized sender 2
     let authorized_minter_2_context = C::new(authorized_minter_address_2.clone());
@@ -161,7 +163,7 @@ fn mint_token() {
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
     assert!(minted.events.is_empty());
-    assert_eq!(Some(120), supply);
+    assert_eq!(Some(110), supply);
 
     // Try to mint new token with authorized sender 1
     let authorized_minter_1_context = C::new(authorized_minter_address_1.clone());
@@ -182,5 +184,5 @@ fn mint_token() {
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
     assert!(minted.events.is_empty());
-    assert_eq!(Some(130), supply);
+    assert_eq!(Some(120), supply);
 }

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -72,18 +72,21 @@ fn mint_token() {
     assert_eq!(Some(initial_balance + mint_amount), total_supply);
 
     // check user balance after minting
-    let bal = query_user_balance(new_holder.clone(),&mut working_set);
-    assert_eq!(Some(10),bal);
+    let bal = query_user_balance(new_holder.clone(), &mut working_set);
+    assert_eq!(Some(10), bal);
 
     // check original token creation balance
-    let bal = query_user_balance(minter_address.clone(),&mut working_set);
-    assert_eq!(Some(100),bal);
+    let bal = query_user_balance(minter_address.clone(), &mut working_set);
+    assert_eq!(Some(100), bal);
 
     // Mint with an un-authorized user
     let unauthorized_address = generate_address("unauthorized_address");
     let unauthorized_context = C::new(unauthorized_address.clone());
-    let unauthorized_mint = bank
-        .call(mint_message.clone(), &unauthorized_context, &mut working_set);
+    let unauthorized_mint = bank.call(
+        mint_message.clone(),
+        &unauthorized_context,
+        &mut working_set,
+    );
 
     assert!(unauthorized_mint.is_err());
     let expected_error = format!(
@@ -92,5 +95,4 @@ fn mint_token() {
     );
     let actual_msg = unauthorized_mint.err().unwrap().to_string();
     assert!(actual_msg.contains(&expected_error));
-
 }

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -1,13 +1,9 @@
 use helpers::{generate_address, C};
 use sov_bank::call::CallMessage;
-use sov_bank::genesis::{DEPLOYER, SALT};
 use sov_bank::query::TotalSupplyResponse;
 use sov_bank::{create_token_address, Bank, BankConfig, Coins};
 use sov_modules_api::{Address, Context, Module, ModuleInfo};
-use sov_modules_api::Error::ModuleError;
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
-
-use crate::helpers::create_bank_config_with_token;
 
 mod helpers;
 
@@ -20,8 +16,6 @@ fn mint_token() {
     let empty_bank_config = BankConfig::<C> { tokens: vec![] };
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
-    let sender_address = generate_address("just_sender");
-    let sender_context = C::new(sender_address.clone());
     let minter_address = generate_address("minter");
     let minter_context = C::new(minter_address.clone());
 
@@ -76,6 +70,14 @@ fn mint_token() {
 
     let total_supply = query_total_supply(&mut working_set);
     assert_eq!(Some(initial_balance + mint_amount), total_supply);
+
+    // check user balance after minting
+    let bal = query_user_balance(new_holder.clone(),&mut working_set);
+    assert_eq!(Some(10),bal);
+
+    // check original token creation balance
+    let bal = query_user_balance(minter_address.clone(),&mut working_set);
+    assert_eq!(Some(100),bal);
 
     // Mint with an un-authorized user
     let unauthorized_address = generate_address("unauthorized_address");

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -124,7 +124,7 @@ fn mint_token() {
     // No events at the moment. If there are, needs to be checked
     assert!(minted.events.is_empty());
 
-    // Try to mint new token with original Sender
+    // Try to mint new token with original token creator, in this case minter_context
     let mint_amount = 10;
     let new_holder = generate_address("new_holder_2");
     let mint_message = CallMessage::Mint {
@@ -135,13 +135,12 @@ fn mint_token() {
         minter_address: new_holder.clone(),
     };
 
-    let minted = bank.call(mint_message.clone(), &minter_context, &mut working_set);
-    assert!(minted.is_err());
-    let err_msg = format!(
-        "Sender {} is not an authorized minter",
-        minter_address.clone()
-    );
-    assert_eq!(err_msg, minted.err().unwrap().to_string());
+    let minted = bank
+        .call(mint_message.clone(), &minter_context, &mut working_set)
+        .expect("Failed to mint token");
+    let supply = query_total_supply(token_address.clone(), &mut working_set);
+    assert!(minted.events.is_empty());
+    assert_eq!(Some(110), supply);
 
     // Try to mint new token with authorized sender 2
     let authorized_minter_2_context = C::new(authorized_minter_address_2.clone());
@@ -162,7 +161,7 @@ fn mint_token() {
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
     assert!(minted.events.is_empty());
-    assert_eq!(Some(110), supply);
+    assert_eq!(Some(120), supply);
 
     // Try to mint new token with authorized sender 1
     let authorized_minter_1_context = C::new(authorized_minter_address_1.clone());
@@ -183,5 +182,5 @@ fn mint_token() {
         .expect("Failed to mint token");
     let supply = query_total_supply(token_address.clone(), &mut working_set);
     assert!(minted.events.is_empty());
-    assert_eq!(Some(120), supply);
+    assert_eq!(Some(130), supply);
 }

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -242,6 +242,7 @@ fn transfer_deployed_token() {
         token_name,
         initial_balance,
         minter_address: sender_address.clone(),
+        authorized_minters: None,
     };
     let minted = bank
         .call(mint_message, &sender_context, &mut working_set)

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -242,7 +242,7 @@ fn transfer_deployed_token() {
         token_name,
         initial_balance,
         minter_address: sender_address.clone(),
-        authorized_minters: None,
+        authorized_minters: vec![sender_address.clone()],
     };
     let minted = bank
         .call(mint_message, &sender_context, &mut working_set)


### PR DESCRIPTION
add mint and freeze functionality to bank module.
changes
- create: 
  - store a vector of authorized minters. currently hardcoded to a single element "sender" who created the token
  - boolean flag freeze
- freeze: sets freeze to true if not set, errors otherwise. only authorized minter allowed
- mint: mints coins to specified address, only if not frozen and if sender is in authorized minters

wip, tests in progress