### PR TITLE
Move `events` to WorkingSet

### DIFF
--- a/examples/demo-nft-module/Cargo.toml
+++ b/examples/demo-nft-module/Cargo.toml
@@ -20,6 +20,8 @@ sov-state = { path = "../../module-system/sov-state", default-features = false }
 
 [dev-dependencies]
 sov-state = { path = "../../module-system/sov-state", features = ["temp"] }
+sov-rollup-interface =  { path = "../../rollup-interface" }
+
 
 [features]
 default = ["native"]

--- a/examples/demo-nft-module/README.md
+++ b/examples/demo-nft-module/README.md
@@ -274,6 +274,8 @@ impl<C: Context> NonFungibleToken<C> {
         }
 
         self.owners.set(&id, context.sender().clone(), working_set);
+
+        working_set.add_event("NFT mint", &format!("A token with id {id} was minted"));
         Ok(CallResponse::default())
     }
 
@@ -294,6 +296,10 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Only token owner can transfer token");
         }
         self.owners.set(&id, to, working_set);
+        working_set.add_event(
+            "NFT transfer",
+            &format!("A token with id {id} was transferred"),
+        );
         Ok(CallResponse::default())
     }
 
@@ -313,6 +319,8 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Only token owner can burn token");
         }
         self.owners.remove(&id, working_set);
+
+        working_set.add_event("NFT transfer", &format!("A token with id {id} was burned"));
         Ok(CallResponse::default())
     }
 }

--- a/examples/demo-nft-module/README.md
+++ b/examples/demo-nft-module/README.md
@@ -320,7 +320,7 @@ impl<C: Context> NonFungibleToken<C> {
         }
         self.owners.remove(&id, working_set);
 
-        working_set.add_event("NFT transfer", &format!("A token with id {id} was burned"));
+        working_set.add_event("NFT burn", &format!("A token with id {id} was burned"));
         Ok(CallResponse::default())
     }
 }

--- a/examples/demo-nft-module/src/call.rs
+++ b/examples/demo-nft-module/src/call.rs
@@ -83,7 +83,7 @@ impl<C: Context> NonFungibleToken<C> {
         }
         self.owners.remove(&id, working_set);
 
-        working_set.add_event("NFT transfer", &format!("A token with id {id} was burned"));
+        working_set.add_event("NFT burn", &format!("A token with id {id} was burned"));
         Ok(CallResponse::default())
     }
 }

--- a/examples/demo-nft-module/src/call.rs
+++ b/examples/demo-nft-module/src/call.rs
@@ -37,6 +37,8 @@ impl<C: Context> NonFungibleToken<C> {
         }
 
         self.owners.set(&id, context.sender().clone(), working_set);
+
+        working_set.add_event("NFT mint", &format!("A token with id {id} was minted"));
         Ok(CallResponse::default())
     }
 
@@ -57,6 +59,10 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Only token owner can transfer token");
         }
         self.owners.set(&id, to, working_set);
+        working_set.add_event(
+            "NFT transfer",
+            &format!("A token with id {id} was transferred"),
+        );
         Ok(CallResponse::default())
     }
 
@@ -76,6 +82,8 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Only token owner can burn token");
         }
         self.owners.remove(&id, working_set);
+
+        working_set.add_event("NFT transfer", &format!("A token with id {id} was burned"));
         Ok(CallResponse::default())
     }
 }

--- a/examples/demo-nft-module/tests/nft_test.rs
+++ b/examples/demo-nft-module/tests/nft_test.rs
@@ -20,7 +20,7 @@ fn genesis_and_mint() {
     let owner1 = generate_address("owner2");
     let owner2 = generate_address("owner2");
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
-        admin: admin.clone(),
+        admin,
         owners: vec![(0, owner1.clone())],
     };
     let mut working_set = WorkingSet::new(ProverStorage::temporary());
@@ -31,7 +31,7 @@ fn genesis_and_mint() {
     assert!(genesis_result.is_ok());
 
     let query1: OwnerResponse<C> = nft.get_owner(0, &mut working_set);
-    assert_eq!(query1.owner, Some(owner1.clone()));
+    assert_eq!(query1.owner, Some(owner1));
 
     let query2: OwnerResponse<C> = nft.get_owner(1, &mut working_set);
     assert!(query2.owner.is_none());
@@ -39,15 +39,15 @@ fn genesis_and_mint() {
     // Mint, anybody can mint
     let mint_message = CallMessage::Mint { id: 1 };
     let owner2_context = C::new(owner2.clone());
-    let minted = nft
-        .call(mint_message.clone(), &owner2_context, &mut working_set)
+    nft.call(mint_message.clone(), &owner2_context, &mut working_set)
         .expect("Minting failed");
-    assert!(working_set.events().is_empty());
+
+    assert!(!working_set.events().is_empty());
     let query3: OwnerResponse<C> = nft.get_owner(1, &mut working_set);
-    assert_eq!(query3.owner, Some(owner2.clone()));
+    assert_eq!(query3.owner, Some(owner2));
 
     // Try to mint again same token, should fail
-    let mint_attempt = nft.call(mint_message.clone(), &owner2_context, &mut working_set);
+    let mint_attempt = nft.call(mint_message, &owner2_context, &mut working_set);
 
     assert!(mint_attempt.is_err());
     let error_message = mint_attempt.err().unwrap().to_string();
@@ -90,13 +90,12 @@ fn transfer() {
 
     // Normal transfer
     let token1_owner = query_token_owner(1, &mut working_set);
-    assert_eq!(Some(owner1.clone()), token1_owner);
-    let transfer = nft
-        .call(transfer_message, &owner1_context, &mut working_set)
+    assert_eq!(Some(owner1), token1_owner);
+    nft.call(transfer_message, &owner1_context, &mut working_set)
         .expect("Transfer failed");
-    assert!(working_set.events().is_empty());
+    assert!(!working_set.events().is_empty());
     let token1_owner = query_token_owner(1, &mut working_set);
-    assert_eq!(Some(owner2.clone()), token1_owner);
+    assert_eq!(Some(owner2), token1_owner);
 
     // Attempt to transfer non existing token
     let transfer_message = CallMessage::Transfer { id: 3, to: admin };
@@ -116,8 +115,8 @@ fn burn() {
     let owner1 = generate_address("owner2");
     let owner1_context = C::new(owner1.clone());
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
-        admin: admin.clone(),
-        owners: vec![(0, owner1.clone())],
+        admin,
+        owners: vec![(0, owner1)],
     };
 
     let mut working_set = WorkingSet::new(ProverStorage::temporary());
@@ -134,16 +133,15 @@ fn burn() {
     assert_eq!("Only token owner can burn token", error_message);
 
     // Normal burn
-    let burned = nft
-        .call(burn_message.clone(), &owner1_context, &mut working_set)
+    nft.call(burn_message.clone(), &owner1_context, &mut working_set)
         .expect("Burn failed");
-    assert!(working_set.events().is_empty());
+    assert!(!working_set.events().is_empty());
 
     let query: OwnerResponse<C> = nft.get_owner(0, &mut working_set);
 
     assert!(query.owner.is_none());
 
-    let burn_attempt = nft.call(burn_message.clone(), &owner1_context, &mut working_set);
+    let burn_attempt = nft.call(burn_message, &owner1_context, &mut working_set);
     assert!(burn_attempt.is_err());
     let error_message = burn_attempt.err().unwrap().to_string();
     assert_eq!("Token with id 0 does not exist", error_message);

--- a/examples/demo-nft-module/tests/nft_test.rs
+++ b/examples/demo-nft-module/tests/nft_test.rs
@@ -42,7 +42,7 @@ fn genesis_and_mint() {
     let minted = nft
         .call(mint_message.clone(), &owner2_context, &mut working_set)
         .expect("Minting failed");
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
     let query3: OwnerResponse<C> = nft.get_owner(1, &mut working_set);
     assert_eq!(query3.owner, Some(owner2.clone()));
 
@@ -94,7 +94,7 @@ fn transfer() {
     let transfer = nft
         .call(transfer_message, &owner1_context, &mut working_set)
         .expect("Transfer failed");
-    assert!(transfer.events.is_empty());
+    assert!(working_set.events().is_empty());
     let token1_owner = query_token_owner(1, &mut working_set);
     assert_eq!(Some(owner2.clone()), token1_owner);
 
@@ -137,7 +137,7 @@ fn burn() {
     let burned = nft
         .call(burn_message.clone(), &owner1_context, &mut working_set)
         .expect("Burn failed");
-    assert!(burned.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let query: OwnerResponse<C> = nft.get_owner(0, &mut working_set);
 

--- a/examples/demo-stf/src/tests/data_generation/election_data.rs
+++ b/examples/demo-stf/src/tests/data_generation/election_data.rs
@@ -156,7 +156,7 @@ impl MessageGenerator for InvalidElectionCallMessages {
 
         messages.extend(call_generator.create_voters_and_vote());
 
-        // Invalid additional message: This voter already voted.
+        // Additional invalid message: This voter already voted.
         {
             let voter = call_generator.voters[0].clone();
             let vote_message = sov_election::call::CallMessage::Vote(1);

--- a/examples/demo-stf/src/tests/data_generation/election_data.rs
+++ b/examples/demo-stf/src/tests/data_generation/election_data.rs
@@ -156,7 +156,7 @@ impl MessageGenerator for InvalidElectionCallMessages {
 
         messages.extend(call_generator.create_voters_and_vote());
 
-        // Invalid message: This voter already voted.
+        // Invalid additional message: This voter already voted.
         {
             let voter = call_generator.voters[0].clone();
             let vote_message = sov_election::call::CallMessage::Vote(1);

--- a/examples/demo-stf/src/tests/mod.rs
+++ b/examples/demo-stf/src/tests/mod.rs
@@ -3,7 +3,7 @@ use sov_default_stf::{AppTemplate, Batch, SequencerOutcome, TxEffect};
 use sov_modules_api::{
     default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Address,
 };
-use sov_rollup_interface::{mocks::MockZkvm, stf::BatchReceipt};
+use sov_rollup_interface::stf::BatchReceipt;
 use sov_state::ProverStorage;
 use std::path::Path;
 

--- a/examples/demo-stf/src/tests/mod.rs
+++ b/examples/demo-stf/src/tests/mod.rs
@@ -1,8 +1,9 @@
 use borsh::BorshSerialize;
-use sov_default_stf::{AppTemplate, Batch};
+use sov_default_stf::{AppTemplate, Batch, SequencerOutcome, TxEffect};
 use sov_modules_api::{
     default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, Address,
 };
+use sov_rollup_interface::{mocks::MockZkvm, stf::BatchReceipt};
 use sov_state::ProverStorage;
 use std::path::Path;
 
@@ -52,4 +53,17 @@ pub fn create_demo_config(
         value_setter_admin_private_key,
         election_admin_private_key,
     )
+}
+
+pub fn events_count(apply_blob_outcome: &BatchReceipt<SequencerOutcome, TxEffect>) -> usize {
+    let events = apply_blob_outcome
+        .tx_receipts
+        .iter()
+        .flat_map(|receipts| receipts.events.iter());
+
+    for e in events.clone() {
+        println!("{:?}", e.try_to_string());
+    }
+
+    events.count()
 }

--- a/examples/demo-stf/src/tests/mod.rs
+++ b/examples/demo-stf/src/tests/mod.rs
@@ -61,5 +61,5 @@ pub fn has_tx_events(apply_blob_outcome: &BatchReceipt<SequencerOutcome, TxEffec
         .iter()
         .flat_map(|receipts| receipts.events.iter());
 
-    events.count() != 0
+    events.peekable().peek().is_some()
 }

--- a/examples/demo-stf/src/tests/mod.rs
+++ b/examples/demo-stf/src/tests/mod.rs
@@ -55,15 +55,11 @@ pub fn create_demo_config(
     )
 }
 
-pub fn events_count(apply_blob_outcome: &BatchReceipt<SequencerOutcome, TxEffect>) -> usize {
+pub fn has_tx_events(apply_blob_outcome: &BatchReceipt<SequencerOutcome, TxEffect>) -> bool {
     let events = apply_blob_outcome
         .tx_receipts
         .iter()
         .flat_map(|receipts| receipts.events.iter());
 
-    for e in events.clone() {
-        println!("{:?}", e.try_to_string());
-    }
-
-    events.count()
+    events.count() != 0
 }

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -4,7 +4,8 @@ pub mod test {
         genesis_config::{DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT},
         runtime::Runtime,
         tests::{
-            create_demo_config, create_new_demo, data_generation::simulate_da, new_test_blob, C,
+            create_demo_config, create_new_demo, data_generation::simulate_da, events_count,
+            new_test_blob, C,
         },
     };
     use sov_default_stf::{Batch, SequencerOutcome};
@@ -13,6 +14,8 @@ pub mod test {
     };
     use sov_rollup_interface::{mocks::MockZkvm, stf::StateTransitionFunction};
     use sov_state::{ProverStorage, WorkingSet};
+
+    const EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION: usize = 10;
 
     #[test]
     fn test_demo_values_in_db() {
@@ -37,12 +40,18 @@ pub mod test {
                 &mut demo,
                 new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
                 None,
-            )
-            .inner;
+            );
+
             assert!(
-                matches!(apply_blob_outcome, SequencerOutcome::Rewarded,),
+                matches!(apply_blob_outcome.inner, SequencerOutcome::Rewarded,),
                 "Sequencer execution should have succeeded but failed "
             );
+
+            assert_eq!(
+                events_count(&apply_blob_outcome),
+                EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION
+            );
+
             StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
         }
 
@@ -90,12 +99,18 @@ pub mod test {
             &mut demo,
             new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
-        )
-        .inner;
+        );
+
         assert!(
-            matches!(apply_blob_outcome, SequencerOutcome::Rewarded,),
+            matches!(apply_blob_outcome.inner, SequencerOutcome::Rewarded,),
             "Sequencer execution should have succeeded but failed "
         );
+
+        assert_eq!(
+            events_count(&apply_blob_outcome),
+            EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION
+        );
+
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
 
         let runtime = &mut Runtime::<DefaultContext>::new();
@@ -187,15 +202,17 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let apply_blob_result = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
-        )
-        .inner;
+        );
+
         assert!(
-            matches!(apply_blob_result, SequencerOutcome::Ignored),
+            matches!(apply_blob_outcome.inner, SequencerOutcome::Ignored),
             "Batch should have been skipped due to insufficient funds"
         );
+
+        assert_eq!(events_count(&apply_blob_outcome), 0);
     }
 }

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -4,7 +4,7 @@ pub mod test {
         genesis_config::{DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT},
         runtime::Runtime,
         tests::{
-            create_demo_config, create_new_demo, data_generation::simulate_da, events_count,
+            create_demo_config, create_new_demo, data_generation::simulate_da, has_tx_events,
             new_test_blob, C,
         },
     };
@@ -14,8 +14,6 @@ pub mod test {
     };
     use sov_rollup_interface::{mocks::MockZkvm, stf::StateTransitionFunction};
     use sov_state::{ProverStorage, WorkingSet};
-
-    const EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION: usize = 10;
 
     #[test]
     fn test_demo_values_in_db() {
@@ -47,10 +45,7 @@ pub mod test {
                 "Sequencer execution should have succeeded but failed "
             );
 
-            assert_eq!(
-                events_count(&apply_blob_outcome),
-                EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION
-            );
+            assert!(has_tx_events(&apply_blob_outcome),);
 
             StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
         }
@@ -106,10 +101,7 @@ pub mod test {
             "Sequencer execution should have succeeded but failed "
         );
 
-        assert_eq!(
-            events_count(&apply_blob_outcome),
-            EVENTS_COUNT_ON_SUCCESSFUL_EXECUTION
-        );
+        assert!(has_tx_events(&apply_blob_outcome),);
 
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
 
@@ -213,6 +205,7 @@ pub mod test {
             "Batch should have been skipped due to insufficient funds"
         );
 
-        assert_eq!(events_count(&apply_blob_outcome), 0);
+        // Assert that there are no events
+        assert!(!has_tx_events(&apply_blob_outcome));
     }
 }

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -50,7 +50,7 @@ fn test_tx_revert() {
             "Unexpected outcome: Batch exeuction should have succeeded"
         );
 
-        // Some events ware observed
+        // Some events were observed
         assert!(has_tx_events(&apply_blob_outcome));
 
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use crate::{
     genesis_config::{DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT},
     runtime::Runtime,

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -3,7 +3,7 @@ use core::panic;
 use crate::{
     genesis_config::{DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT},
     runtime::Runtime,
-    tests::{data_generation::simulate_da_with_bad_serialization, events_count},
+    tests::{data_generation::simulate_da_with_bad_serialization, has_tx_events},
 };
 use sov_default_stf::{Batch, SequencerOutcome, SlashingReason};
 use sov_modules_api::{
@@ -52,8 +52,8 @@ fn test_tx_revert() {
             "Unexpected outcome: Batch exeuction should have succeeded"
         );
 
-        // TODO simulate_da_with_revert_msg gives only election messages
-        assert_eq!(events_count(&apply_blob_outcome), 8);
+        // Some events ware observed
+        assert!(has_tx_events(&apply_blob_outcome));
 
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
     }
@@ -118,8 +118,8 @@ fn test_tx_bad_sig() {
             "Unexpected outcome: Stateless verification should have failed due to invalid signature"
         );
 
-        // The whole batch was reverted
-        assert_eq!(events_count(&apply_blob_outcome), 0);
+        // The batch receipt contains no events.
+        assert!(!has_tx_events(&apply_blob_outcome));
 
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
     }
@@ -177,7 +177,8 @@ fn test_tx_bad_serialization() {
             "Unexpected outcome: Stateless verification should have failed due to invalid signature"
         );
 
-        assert_eq!(events_count(&apply_blob_outcome), 0);
+        // The batch receipt contains no events.
+        assert!(!has_tx_events(&apply_blob_outcome));
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
     }
 

--- a/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -196,7 +196,7 @@ impl LedgerDB {
     ) -> Result<(), anyhow::Error> {
         self.db.put::<EventByNumber>(event_number, event)?;
         self.db
-            .put::<EventByKey>(&(event.key.clone(), tx_number, *event_number), &())
+            .put::<EventByKey>(&(event.key().clone(), tx_number, *event_number), &())
     }
 
     /// Commits a slot to the database by inserting its events, transactions, and batches before

--- a/module-system/module-implementations/examples/sov-election/src/call.rs
+++ b/module-system/module-implementations/examples/sov-election/src/call.rs
@@ -31,6 +31,7 @@ impl<C: sov_modules_api::Context> Election<C> {
 
         let candidates = candidate_names.into_iter().map(Candidate::new).collect();
         self.candidates.set(candidates, working_set);
+        working_set.add_event("Election: set_candidates", "Candidate was set");
 
         Ok(CallResponse::default())
     }
@@ -48,6 +49,11 @@ impl<C: sov_modules_api::Context> Election<C> {
 
         self.allowed_voters
             .set(&voter_address, Voter::fresh(), working_set);
+
+        working_set.add_event(
+            "Election: add_voter",
+            &format!("Voter was added: {voter_address}"),
+        );
 
         Ok(CallResponse::default())
     }
@@ -95,6 +101,11 @@ impl<C: sov_modules_api::Context> Election<C> {
                     .ok_or(anyhow!("Vote count overflow"))?;
 
                 self.candidates.set(candidates, working_set);
+
+                working_set.add_event(
+                    "Election: make_vote",
+                    &format!("Vote from: {} accepted", context.sender()),
+                );
                 Ok(CallResponse::default())
             }
         }
@@ -108,6 +119,7 @@ impl<C: sov_modules_api::Context> Election<C> {
     ) -> Result<CallResponse> {
         self.exit_if_not_admin(context, working_set)?;
         self.is_frozen.set(true, working_set);
+        working_set.add_event("Election: freeze_election", "Election was frozen");
         Ok(CallResponse::default())
     }
 

--- a/module-system/module-implementations/examples/sov-election/src/call.rs
+++ b/module-system/module-implementations/examples/sov-election/src/call.rs
@@ -68,6 +68,11 @@ impl<C: sov_modules_api::Context> Election<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
+        working_set.add_event(
+            "Election: make_vote",
+            &format!("Attempt to make a from: {}", context.sender()),
+        );
+
         let new_number_of_votes = self
             .number_of_votes
             .get(working_set)

--- a/module-system/module-implementations/examples/sov-value-setter/src/call.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/call.rs
@@ -27,8 +27,6 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse> {
-        let mut response = CallResponse::default();
-
         // If admin is not then early return:
         let admin = self.admin.get_or_err(working_set)?;
 
@@ -41,6 +39,6 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
         self.value.set(new_value, working_set);
         working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
-        Ok(response)
+        Ok(CallResponse::default())
     }
 }

--- a/module-system/module-implementations/examples/sov-value-setter/src/call.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/call.rs
@@ -39,7 +39,7 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
 
         // This is how we set a new value:
         self.value.set(new_value, working_set);
-        response.add_event("set", &format!("value_set: {new_value:?}"));
+        working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
         Ok(response)
     }

--- a/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
@@ -46,7 +46,7 @@ fn test_value_setter_helper<C: Context>(
 
     // Test events
     {
-        let call_response = module.call(call_msg, &context, working_set).unwrap();
+        module.call(call_msg, &context, working_set).unwrap();
         let event = &working_set.events()[0];
         assert_eq!(event, &Event::new("set", "value_set: 99"));
     }

--- a/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
@@ -47,7 +47,7 @@ fn test_value_setter_helper<C: Context>(
     // Test events
     {
         let call_response = module.call(call_msg, &context, working_set).unwrap();
-        let event = &call_response.events[0];
+        let event = &working_set.events()[0];
         assert_eq!(event, &Event::new("set", "value_set: 99"));
     }
 

--- a/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
+++ b/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
@@ -113,34 +113,34 @@ fn execute_module_logic<C: Context>(working_set: &mut WorkingSet<C::Storage>) {
 fn test_state_update<C: Context>(working_set: &mut WorkingSet<C::Storage>) {
     let module = <module_c::ModuleC<C> as ModuleInfo>::new();
 
-    let expected_value = StorageValue::new("some_value");
+    let expected_value = "some_value".to_owned();
 
     {
         let prefix = Prefix::new_storage("nested_modules_tests::module_a", "ModuleA", "state_1_a");
-        let key = StorageKey::new(&prefix.into(), &"some_key");
-        let value = working_set.get(key).unwrap();
+        let state_map = StateMap::<String, String>::new(prefix.into());
+        let value = state_map.get(&"some_key".to_owned(), working_set).unwrap();
 
         assert_eq!(expected_value, value);
     }
 
     {
         let prefix = Prefix::new_storage("nested_modules_tests::module_b", "ModuleB", "state_1_b");
-        let key = StorageKey::new(&prefix.into(), &"some_key");
-        let value = working_set.get(key).unwrap();
+        let state_map = StateMap::<String, String>::new(prefix.into());
+        let value = state_map.get(&"some_key".to_owned(), working_set).unwrap();
 
         assert_eq!(expected_value, value);
     }
 
     {
         let prefix = Prefix::new_storage("nested_modules_tests::module_a", "ModuleA", "state_1_a");
-        let key = StorageKey::new(&prefix.into(), &"key_from_b");
-        let value = working_set.get(key).unwrap();
+        let state_map = StateMap::<String, String>::new(prefix.into());
+        let value = state_map.get(&"some_key".to_owned(), working_set).unwrap();
 
         assert_eq!(expected_value, value);
     }
 
     {
         let value = module.mod_1_a.state_2_a.get(working_set).unwrap();
-        assert_eq!("some_value".to_owned(), value);
+        assert_eq!(expected_value, value);
     }
 }

--- a/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
+++ b/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
@@ -1,7 +1,6 @@
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::{Context, ModuleInfo, Prefix};
 use sov_modules_macros::ModuleInfo;
-use sov_state::storage::{StorageKey, StorageValue};
 use sov_state::{ProverStorage, StateMap, StateValue, Storage, WorkingSet, ZkStorage};
 
 pub mod module_a {

--- a/module-system/module-implementations/module-template/src/call.rs
+++ b/module-system/module-implementations/module-template/src/call.rs
@@ -24,11 +24,9 @@ impl<C: sov_modules_api::Context> ExampleModule<C> {
         _context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse> {
-        let mut response = CallResponse::default();
-
         self.value.set(new_value, working_set);
         working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
-        Ok(response)
+        Ok(CallResponse::default())
     }
 }

--- a/module-system/module-implementations/module-template/src/call.rs
+++ b/module-system/module-implementations/module-template/src/call.rs
@@ -27,7 +27,7 @@ impl<C: sov_modules_api::Context> ExampleModule<C> {
         let mut response = CallResponse::default();
 
         self.value.set(new_value, working_set);
-        response.add_event("set", &format!("value_set: {new_value:?}"));
+        working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
         Ok(response)
     }

--- a/module-system/module-implementations/module-template/src/tests.rs
+++ b/module-system/module-implementations/module-template/src/tests.rs
@@ -42,7 +42,7 @@ fn test_value_setter_helper<C: Context>(
 
     // Test events
     {
-        let call_response = module.call(call_msg, &context, working_set).unwrap();
+        module.call(call_msg, &context, working_set).unwrap();
         let event = &working_set.events()[0];
         assert_eq!(event, &Event::new("set", "value_set: 99"));
     }

--- a/module-system/module-implementations/module-template/src/tests.rs
+++ b/module-system/module-implementations/module-template/src/tests.rs
@@ -43,7 +43,7 @@ fn test_value_setter_helper<C: Context>(
     // Test events
     {
         let call_response = module.call(call_msg, &context, working_set).unwrap();
-        let event = &call_response.events[0];
+        let event = &working_set.events()[0];
         assert_eq!(event, &Event::new("set", "value_set: 99"));
     }
 

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -41,7 +41,7 @@ fn burn_deployed_tokens() {
         .call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let query_total_supply = |working_set: &mut WorkingSet<Storage>| -> Option<u64> {
         let total_supply: TotalSupplyResponse = bank.supply_of(token_address.clone(), working_set);
@@ -69,7 +69,7 @@ fn burn_deployed_tokens() {
     let burned = bank
         .call(burn_message.clone(), &minter_context, &mut working_set)
         .expect("Failed to burn token");
-    assert!(burned.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let current_total_supply = query_total_supply(&mut working_set);
     assert_eq!(Some(initial_balance - burn_amount), current_total_supply);
@@ -104,7 +104,7 @@ fn burn_deployed_tokens() {
     let burned_zero = bank
         .call(burn_zero_message, &minter_context, &mut working_set)
         .expect("Failed to burn token");
-    assert!(burned_zero.events.is_empty());
+    assert!(working_set.events().is_empty());
     let minter_balance_after = query_user_balance(minter_address.clone(), &mut working_set);
     assert_eq!(minter_balance, minter_balance_after);
 
@@ -175,7 +175,7 @@ fn burn_initial_tokens() {
     let burned = bank
         .call(burn_message.clone(), &context, &mut working_set)
         .expect("Failed to burn token");
-    assert!(burned.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let balance_after = query_user_balance(sender_address, &mut working_set);
     assert_eq!(Some(initial_balance - burn_amount), balance_after);

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -37,8 +37,7 @@ fn burn_deployed_tokens() {
         initial_balance,
         minter_address: minter_address.clone(),
     };
-    let minted = bank
-        .call(mint_message, &minter_context, &mut working_set)
+    bank.call(mint_message, &minter_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
     assert!(working_set.events().is_empty());
@@ -66,8 +65,7 @@ fn burn_deployed_tokens() {
         },
     };
 
-    let burned = bank
-        .call(burn_message.clone(), &minter_context, &mut working_set)
+    bank.call(burn_message.clone(), &minter_context, &mut working_set)
         .expect("Failed to burn token");
     assert!(working_set.events().is_empty());
 
@@ -101,8 +99,7 @@ fn burn_deployed_tokens() {
         },
     };
 
-    let burned_zero = bank
-        .call(burn_zero_message, &minter_context, &mut working_set)
+    bank.call(burn_zero_message, &minter_context, &mut working_set)
         .expect("Failed to burn token");
     assert!(working_set.events().is_empty());
     let minter_balance_after = query_user_balance(minter_address.clone(), &mut working_set);
@@ -172,8 +169,7 @@ fn burn_initial_tokens() {
     };
 
     let context = C::new(sender_address.clone());
-    let burned = bank
-        .call(burn_message.clone(), &context, &mut working_set)
+    bank.call(burn_message, &context, &mut working_set)
         .expect("Failed to burn token");
     assert!(working_set.events().is_empty());
 

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -28,8 +28,7 @@ fn initial_and_deployed_token() {
         minter_address: minter_address.clone(),
     };
 
-    let create_token_response = bank
-        .call(create_token_message, &sender_context, &mut working_set)
+    bank.call(create_token_message, &sender_context, &mut working_set)
         .expect("Failed to create token");
 
     assert!(working_set.events().is_empty());

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -32,7 +32,7 @@ fn initial_and_deployed_token() {
         .call(create_token_message, &sender_context, &mut working_set)
         .expect("Failed to create token");
 
-    assert!(create_token_response.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let sender_balance =
         bank.get_balance_of(sender_address, token_address.clone(), &mut working_set);

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -58,7 +58,7 @@ fn transfer_initial_token() {
         let transferred = bank
             .call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
-        assert!(transferred.events.is_empty());
+        assert!(working_set.events().is_empty());
 
         let sender_balance_after = query_user_balance(sender_address.clone(), &mut working_set);
         let receiver_balance_after = query_user_balance(receiver_address.clone(), &mut working_set);
@@ -169,7 +169,7 @@ fn transfer_initial_token() {
         let transferred = bank
             .call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
-        assert!(transferred.events.is_empty());
+        assert!(working_set.events().is_empty());
 
         let receiver_balance_after = query_user_balance(unknown_receiver, &mut working_set);
         assert_eq!(Some(1), receiver_balance_after)
@@ -191,7 +191,7 @@ fn transfer_initial_token() {
         let transferred = bank
             .call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
-        assert!(transferred.events.is_empty());
+        assert!(working_set.events().is_empty());
 
         let sender_balance_after = query_user_balance(sender_address, &mut working_set);
         assert_eq!(sender_balance_before, sender_balance_after);
@@ -247,7 +247,7 @@ fn transfer_deployed_token() {
         .call(mint_message, &sender_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
-    assert!(minted.events.is_empty());
+    assert!(working_set.events().is_empty());
     let total_supply_before = query_total_supply(&mut working_set);
     assert!(total_supply_before.is_some());
 
@@ -269,7 +269,7 @@ fn transfer_deployed_token() {
     let transferred = bank
         .call(transfer_message, &sender_context, &mut working_set)
         .expect("Transfer call failed");
-    assert!(transferred.events.is_empty());
+    assert!(working_set.events().is_empty());
 
     let sender_balance_after = query_user_balance(sender_address, &mut working_set);
     let receiver_balance_after = query_user_balance(receiver_address, &mut working_set);

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -55,8 +55,7 @@ fn transfer_initial_token() {
             },
         };
 
-        let transferred = bank
-            .call(transfer_message, &sender_context, &mut working_set)
+        bank.call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
         assert!(working_set.events().is_empty());
 
@@ -166,8 +165,7 @@ fn transfer_initial_token() {
             },
         };
 
-        let transferred = bank
-            .call(transfer_message, &sender_context, &mut working_set)
+        bank.call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
         assert!(working_set.events().is_empty());
 
@@ -188,8 +186,7 @@ fn transfer_initial_token() {
                 token_address: token_address.clone(),
             },
         };
-        let transferred = bank
-            .call(transfer_message, &sender_context, &mut working_set)
+        bank.call(transfer_message, &sender_context, &mut working_set)
             .expect("Transfer call failed");
         assert!(working_set.events().is_empty());
 
@@ -243,8 +240,7 @@ fn transfer_deployed_token() {
         initial_balance,
         minter_address: sender_address.clone(),
     };
-    let minted = bank
-        .call(mint_message, &sender_context, &mut working_set)
+    bank.call(mint_message, &sender_context, &mut working_set)
         .expect("Failed to mint token");
     // No events at the moment. If there are, needs to be checked
     assert!(working_set.events().is_empty());
@@ -266,8 +262,7 @@ fn transfer_deployed_token() {
         },
     };
 
-    let transferred = bank
-        .call(transfer_message, &sender_context, &mut working_set)
+    bank.call(transfer_message, &sender_context, &mut working_set)
         .expect("Transfer call failed");
     assert!(working_set.events().is_empty());
 

--- a/module-system/module-implementations/sov-prover-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/call.rs
@@ -27,8 +27,6 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
         prover: &C::Address,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
-        let mut response = CallResponse::default();
-
         // Transfer the bond amount from the sender to the module's address.
         // On failure, no state is changed
         let coins = Coins {
@@ -56,7 +54,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             &format!("new_deposit: {bond_amount:?}. total_bond: {total_balance:?}"),
         );
 
-        Ok(response)
+        Ok(CallResponse::default())
     }
 
     /// Try to bond the requested amount of coins from context.sender()
@@ -75,8 +73,6 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse> {
-        let mut response = CallResponse::default();
-
         // Get the prover's old balance.
         if let Some(old_balance) = self.bonded_provers.get(context.sender(), working_set) {
             // Transfer the bond amount from the sender to the module's address.
@@ -103,7 +99,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             );
         }
 
-        Ok(response)
+        Ok(CallResponse::default())
     }
 
     /// Try to process a zk proof, if the prover is bonded.
@@ -113,8 +109,6 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse> {
-        let mut response = CallResponse::default();
-
         // Get the prover's old balance.
         // Revert if they aren't bonded
         let old_balance = self
@@ -158,6 +152,6 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             );
         }
 
-        Ok(response)
+        Ok(CallResponse::default())
     }
 }

--- a/module-system/module-implementations/sov-prover-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/call.rs
@@ -51,7 +51,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
         self.bonded_provers.set(prover, total_balance, working_set);
 
         // Emit the bonding event
-        response.add_event(
+        working_set.add_event(
             "bonded_prover",
             &format!("new_deposit: {bond_amount:?}. total_bond: {total_balance:?}"),
         );
@@ -97,7 +97,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             self.bonded_provers.set(context.sender(), 0, working_set);
 
             // Emit the unbonding event
-            response.add_event(
+            working_set.add_event(
                 "unbonded_prover",
                 &format!("amount_withdrawn: {old_balance:?}"),
             );
@@ -147,12 +147,12 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             self.bonded_provers
                 .set(context.sender(), old_balance, working_set);
 
-            response.add_event(
+            working_set.add_event(
                 "processed_valid_proof",
                 &format!("prover: {:?}", context.sender()),
             );
         } else {
-            response.add_event(
+            working_set.add_event(
                 "processed_invalid_proof",
                 &format!("slashed_prover: {:?}", context.sender()),
             );

--- a/module-system/sov-default-stf/src/lib.rs
+++ b/module-system/sov-default-stf/src/lib.rs
@@ -80,7 +80,8 @@ where
             };
         }
 
-        // TODO
+        // TODO: don't ignore these events.
+        // https://github.com/Sovereign-Labs/sovereign/issues/350
         let _ = batch_workspace.take_events();
 
         // Commit `enter_apply_batch` changes.

--- a/module-system/sov-modules-api/src/response.rs
+++ b/module-system/sov-modules-api/src/response.rs
@@ -1,14 +1,3 @@
-use sov_rollup_interface::stf::Event;
-
 /// Response type for the `Module::call` method.
 #[derive(Default)]
-pub struct CallResponse {
-    /// Lists of events emitted by a call to a module.
-    pub events: Vec<Event>,
-}
-
-impl CallResponse {
-    pub fn add_event(&mut self, key: &str, value: &str) {
-        self.events.push(Event::new(key, value))
-    }
-}
+pub struct CallResponse {}

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { workspace = true }
 borsh = { workspace = true}
 serde = { workspace = true }
 thiserror = { workspace = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
 sov-db = { path = "../../full-node/db/sov-db", optional = true}
 first-read-last-write-cache = { path = "../utils/first-read-last-write-cache" }
 jmt = { workspace = true }

--- a/module-system/sov-state/src/scratchpad.rs
+++ b/module-system/sov-state/src/scratchpad.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_rollup_interface::stf::{Event, EventKey};
+use sov_rollup_interface::stf::Event;
 use std::{collections::HashMap, fmt::Debug};
 
 use crate::{
@@ -24,7 +24,7 @@ pub struct Delta<S: Storage> {
 ///
 /// All reads are recorded in the underlying delta, because even reverted transactions have to be proven to have
 /// executed against the correct state. (If the state was different, the transaction may not have reverted.)
-pub struct RevertableDelta<S: Storage> {
+struct RevertableDelta<S: Storage> {
     /// The inner (non-revertable) delta
     inner: Delta<S>,
     /// A cache containing the most recent values written. Reads are first checked
@@ -46,6 +46,7 @@ enum ReadWriteSet<S: Storage> {
     Revertable(RevertableDelta<S>),
 }
 
+///
 pub struct WorkingSet<S: Storage> {
     //
     read_write_set: ReadWriteSet<S>,

--- a/module-system/sov-state/src/scratchpad.rs
+++ b/module-system/sov-state/src/scratchpad.rs
@@ -46,11 +46,9 @@ enum ReadWriteSet<S: Storage> {
     Revertable(RevertableDelta<S>),
 }
 
-///
+/// This structure holds the read-write set and the events gathered during the execution of a transaction.
 pub struct WorkingSet<S: Storage> {
-    //
     read_write_set: ReadWriteSet<S>,
-    //
     events: Vec<Event>,
 }
 

--- a/module-system/sov-state/src/scratchpad.rs
+++ b/module-system/sov-state/src/scratchpad.rs
@@ -100,7 +100,8 @@ impl<S: Storage> WorkingSet<S> {
         };
         Self {
             read_write_set,
-            events: self.events,
+            // The `revert` removes all events associated with the transaction
+            events: Vec::default(),
         }
     }
 
@@ -139,7 +140,6 @@ impl<S: Storage> WorkingSet<S> {
 
     pub fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
         match &mut self.read_write_set {
-            // todo
             ReadWriteSet::Standard(delta) => delta.freeze(),
             ReadWriteSet::Revertable(_) => todo!(),
         }

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -126,8 +126,8 @@ pub enum ConsensusRole {
 /// A key-value pair representing a change to the rollup state
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct Event {
-    pub key: EventKey,
-    pub value: EventValue,
+    key: EventKey,
+    value: EventValue,
 }
 
 impl Event {
@@ -138,11 +138,12 @@ impl Event {
         }
     }
 
-    pub fn try_to_string(&self) -> Result<String, Utf8Error> {
-        let key = std::str::from_utf8(&self.key.0)?;
-        let value = std::str::from_utf8(&self.value.0)?;
+    pub fn key(&self) -> &EventKey {
+        &self.key
+    }
 
-        Ok(format!("Event: key: {key}, value: {value}"))
+    pub fn value(&self) -> &EventValue {
+        &self.value
     }
 }
 

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -1,3 +1,5 @@
+use std::str::Utf8Error;
+
 use crate::{da::BlobTransactionTrait, maybestd::rc::Rc, zk::traits::Zkvm};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -134,6 +136,13 @@ impl Event {
             key: EventKey(key.as_bytes().to_vec()),
             value: EventValue(value.as_bytes().to_vec()),
         }
+    }
+
+    pub fn try_to_string(&self) -> Result<String, Utf8Error> {
+        let key = std::str::from_utf8(&self.key.0)?;
+        let value = std::str::from_utf8(&self.value.0)?;
+
+        Ok(format!("Event: key: {key}, value: {value}"))
     }
 }
 

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -1,5 +1,3 @@
-use std::str::Utf8Error;
-
 use crate::{da::BlobTransactionTrait, maybestd::rc::Rc, zk::traits::Zkvm};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};


### PR DESCRIPTION
# Description
This PR introduces the following changes:
1. The `events` field is moved from the `CallResponse` to the `WorkingSet`.
2. The `WorkingSet` is refactored with `events` handling.
3. The `election, value-setter & nft` modules are updated to include additional `events`.
4. The `sov-default-stf`  is refactored, and `TransactionReceipt` gets `events` from `WorkingSet`.

## Linked Issues
- Fixes #233
- Related to #349, #350

## Testing
1. A check for correct `events` propagation was added in the `nested-module-test`.
2. Updated tests in `election, value-setter & nft` modules to verify the correct propagation of events. 
3. Updated `demo-stf` tests to verify the correct propagation of events.
 
## Docs
Updated docs for the `nft` module. 
